### PR TITLE
Add draw logic to cheating mode

### DIFF
--- a/tictactoe.html
+++ b/tictactoe.html
@@ -22,6 +22,7 @@
         <div class="controls">
             <label for="difficulty">Difficulty:</label>
             <select id="difficulty">
+                <option value="cheater">Cheater</option>
                 <option value="impossible">Impossible</option>
                 <option value="hard">Hard</option>
                 <option value="normal" selected>Normal</option>


### PR DESCRIPTION
## Summary
- detect simultaneous wins during cheater moves and declare a draw

## Testing
- `node --check tictactoe.js`


------
https://chatgpt.com/codex/tasks/task_e_6846017b614c83239ffd387c7df57736