### PR TITLE
Add explosion physics on Tic-Tac-Toe loss

### DIFF
--- a/tictactoe.css
+++ b/tictactoe.css
@@ -33,3 +33,16 @@
 .controls {
     margin-bottom: 10px;
 }
+
+/* Physics effect when the player loses */
+.board.physics {
+    position: relative;
+    overflow-x: hidden;
+    overflow-y: visible;
+    height: 300px; /* allow cells to fall */
+}
+
+.board.physics .cell {
+    position: absolute;
+    pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add physics styles for the board when player loses
- trigger `explodeBoard()` when the AI wins
- implement simple physics simulation for exploding cells
- reset board styles on restart

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846077fb4508323a7c28e18762ecc86