### PR TITLE
Add full-page physics overlay for losing animation

### DIFF
--- a/tictactoe.css
+++ b/tictactoe.css
@@ -33,3 +33,28 @@
 .controls {
     margin-bottom: 10px;
 }
+
+/* Physics effect overlay when the player loses */
+.board.physics {
+    visibility: hidden;
+}
+
+.physics-overlay {
+    position: fixed;
+    left: 0;
+    top: 0;
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 1000;
+}
+
+.physics-overlay .floor {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 20px;
+    background-color: #21262d;
+}


### PR DESCRIPTION
## Summary
- update board physics styles for overlay approach
- create full-page overlay with floor when AI wins
- animate falling cells with boundaries across the window
- clean up overlay and animation on restart

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846077fb4508323a7c28e18762ecc86