### PR TITLE
Add radial explosion and circular physics

### DIFF
--- a/tictactoe.html
+++ b/tictactoe.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="Style.css">
     <link rel="stylesheet" href="tictactoe.css">
+    <script src="https://cdn.jsdelivr.net/npm/matter-js@0.19.0/build/matter.min.js"></script>
     <script src="tictactoe.js" defer></script>
 </head>
 <body>

--- a/tictactoe.js
+++ b/tictactoe.js
@@ -9,6 +9,11 @@ document.addEventListener('DOMContentLoaded', () => {
     let aiSymbol;
     let gameOver;
 
+    // Physics related variables
+    let engine;
+    let physicsCells = [];
+    let physicsActive = false;
+
     function createBoard() {
         boardEl.innerHTML = '';
         board = Array(9).fill(null);
@@ -22,6 +27,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function restartGame() {
+        clearPhysics();
         createBoard();
         gameOver = false;
         if (Math.random() < 0.5) {
@@ -76,6 +82,9 @@ document.addEventListener('DOMContentLoaded', () => {
         if (winner) {
             statusEl.textContent = winner === 'draw' ? 'Draw!' : `${winner} wins!`;
             gameOver = true;
+            if (winner === aiSymbol) {
+                explodeBoard();
+            }
         }
     }
 
@@ -195,6 +204,91 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         if (bd.every(v => v)) return 'draw';
         return null;
+    }
+
+    function clearPhysics() {
+        if (!physicsActive) return;
+        physicsActive = false;
+        physicsCells.forEach(cell => {
+            if (cell._body) {
+                Matter.World.remove(engine.world, cell._body);
+                delete cell._body;
+            }
+            cell.remove();
+        });
+        physicsCells = [];
+        engine = null;
+    }
+
+    function explodeBoard() {
+        if (physicsActive) return;
+        physicsActive = true;
+        engine = Matter.Engine.create();
+        const world = engine.world;
+
+        const width = window.innerWidth;
+        const height = window.innerHeight;
+        const thickness = 100;
+
+        const boundaries = [
+            Matter.Bodies.rectangle(width/2, -thickness/2, width, thickness, { isStatic: true }),
+            Matter.Bodies.rectangle(width/2, height + thickness/2, width, thickness, {
+                isStatic: true,
+                friction: 0
+            }),
+            Matter.Bodies.rectangle(-thickness/2, height/2, thickness, height, { isStatic: true }),
+            Matter.Bodies.rectangle(width + thickness/2, height/2, thickness, height, { isStatic: true })
+        ];
+        Matter.World.add(world, boundaries);
+
+        const boardRect = boardEl.getBoundingClientRect();
+        const center = {
+            x: boardRect.left + boardRect.width / 2,
+            y: boardRect.top + boardRect.height / 2
+        };
+
+        const cells = Array.from(boardEl.children);
+        cells.forEach(cell => {
+            const rect = cell.getBoundingClientRect();
+            cell.style.position = 'absolute';
+            cell.style.left = rect.left + 'px';
+            cell.style.top = rect.top + 'px';
+            cell.style.margin = '0';
+            cell.style.pointerEvents = 'none';
+            document.body.appendChild(cell);
+
+            const radius = rect.width / 2;
+            const body = Matter.Bodies.circle(rect.left + radius, rect.top + radius, radius, {
+                restitution: 0.4
+            });
+            Matter.World.add(world, body);
+
+            const dirX = body.position.x - center.x;
+            const dirY = body.position.y - center.y;
+            const len = Math.hypot(dirX, dirY) || 1;
+            const forceScale = 0.002;
+            Matter.Body.applyForce(body, body.position, {
+                x: (dirX / len) * forceScale,
+                y: (dirY / len) * forceScale
+            });
+
+            cell._body = body;
+            cell._width = rect.width;
+            cell._height = rect.height;
+            physicsCells.push(cell);
+        });
+
+        Matter.Engine.run(engine);
+        (function update() {
+            if (!physicsActive) return;
+            Matter.Engine.update(engine, 1000/60);
+            physicsCells.forEach(cell => {
+                const pos = cell._body.position;
+                cell.style.left = (pos.x - cell._width/2) + 'px';
+                cell.style.top = (pos.y - cell._height/2) + 'px';
+            });
+            requestAnimationFrame(update);
+        })();
     }
 
     restartBtn.addEventListener('click', restartGame);


### PR DESCRIPTION
## Summary
- make the bottom boundary frictionless so pieces slide
- replace rectangle bodies with circles but keep square DOM cells
- push cells outward from the board's center when the AI wins

## Testing
- `node --check tictactoe.js`


------
https://chatgpt.com/codex/tasks/task_e_68460fd931ac83238d07840fb03a3a3e