### PR TITLE
Fix restart button visibility and hide AI cards

### DIFF
--- a/Style.css
+++ b/Style.css
@@ -98,6 +98,20 @@ option, label {
     background-color: #30363d; /* Hover state */
     color: #58a6ff;
 }
+.rest {
+    margin: 5px;
+    padding: 10px;
+    border-radius: 5px;
+    border: none;
+    background-color: #58a6ff;
+    color: #0d1117;
+    font-family: 'Orbitron', sans-serif;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+.rest:hover {
+    background-color: #79c0ff;
+}
 button:hover {
     background-color: #30363d; /* Hover state */
     color: #58a6ff;

--- a/tactic21.js
+++ b/tactic21.js
@@ -64,14 +64,16 @@ document.addEventListener('DOMContentLoaded', () => {
         hand.forEach((value, idx) => {
             const card = document.createElement('div');
             card.className = 'card';
-            card.textContent = value;
+            card.textContent = player === 2 ? '?' : value;
             card.dataset.index = idx;
-            card.addEventListener('click', () => {
-                if (gameOver || currentPlayer !== player) return;
-                selectedCardIndex = idx;
-                Array.from(el.children).forEach(c => c.classList.remove('selected'));
-                card.classList.add('selected');
-            });
+            if (player === 1) {
+                card.addEventListener('click', () => {
+                    if (gameOver || currentPlayer !== player) return;
+                    selectedCardIndex = idx;
+                    Array.from(el.children).forEach(c => c.classList.remove('selected'));
+                    card.classList.add('selected');
+                });
+            }
             el.appendChild(card);
         });
     }


### PR DESCRIPTION
## Summary
- style restart buttons so they're visible
- hide AI card values in Tactic-21

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684629eb581c8323a302869f5811b954