### PR TITLE
Adjust Tactic-21 starting hand size

### DIFF
--- a/tactic21.html
+++ b/tactic21.html
@@ -35,7 +35,7 @@
             <span class="close" onclick="document.getElementById('rulesModal').style.display='none'">&times;</span>
             <h2>Tactic-21 Rules</h2>
             <p><strong>Goal:</strong> Create a line of three cards that sums exactly to 21.</p>
-            <p><strong>Setup:</strong> Each player starts with five random cards drawn from a deck containing four of each value from 1 to 11.</p>
+            <p><strong>Setup:</strong> Each player starts with four random cards drawn from a deck containing four of each value from 1 to 11.</p>
             <p><strong>Turn:</strong> On your turn, select a card from your hand and place it on an empty cell. Draw a new card if the deck still has cards.</p>
             <p><strong>Winning:</strong> You win immediately when you form a horizontal, vertical or diagonal line of your own cards totaling 21. If the board fills without a 21 line, lines totaling 20 are worth 1 point and lines totaling 19 are worth 0.5 points. The higher score wins.</p>
         </div>

--- a/tactic21.js
+++ b/tactic21.js
@@ -42,7 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function dealHands() {
         hands = {1: [], 2: []};
         for (let p = 1; p <= 2; p++) {
-            for (let i = 0; i < 5; i++) {
+            for (let i = 0; i < 4; i++) {
                 drawCard(p);
             }
         }


### PR DESCRIPTION
## Summary
- tweak Tactic-21 rules to specify four cards in hand
- deal four cards per player at the start of a game

## Testing
- `node --check tactic21.js`

------
https://chatgpt.com/codex/tasks/task_e_684634c08d2c8323aeaff9355e74bfd8