### PR TITLE
Fix Tic Tac Toe color update in cheater mode

### DIFF
--- a/tictactoe.js
+++ b/tictactoe.js
@@ -119,9 +119,16 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (aiWin) {
                     const playerWin = hasWin(copy, playerSymbol);
                     board[from] = aiSymbol;
-                    boardEl.children[from].textContent = aiSymbol;
+                    const fromCell = boardEl.children[from];
+                    fromCell.textContent = aiSymbol;
+                    fromCell.classList.remove('player-cell', 'ai-cell');
+                    fromCell.classList.add('ai-cell');
+
                     board[to] = playerSymbol;
-                    boardEl.children[to].textContent = playerSymbol;
+                    const toCell = boardEl.children[to];
+                    toCell.textContent = playerSymbol;
+                    toCell.classList.remove('player-cell', 'ai-cell');
+                    toCell.classList.add('player-cell');
                     let result;
                     if (aiWin && playerWin) {
                         result = 'draw';


### PR DESCRIPTION
## Summary
- ensure moved cells update their player/AI color in cheater mode

## Testing
- `npm test` *(fails: missing `package.json`)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68463c3fd0cc8323a2fe25eecc0b3cad