### PR TITLE
Make AI cards red in Tactic-21

### DIFF
--- a/tactic21.css
+++ b/tactic21.css
@@ -52,6 +52,10 @@
     cursor: pointer;
     color: #58a6ff;
 }
+.card.ai-card {
+    color: #ff7b72;
+    border-color: #ff7b72;
+}
 .card.selected {
     border-color: yellow;
 }

--- a/tactic21.js
+++ b/tactic21.js
@@ -70,6 +70,9 @@ document.addEventListener('DOMContentLoaded', () => {
         hand.forEach((value, idx) => {
             const card = document.createElement('div');
             card.className = 'card';
+            if (player === 2) {
+                card.classList.add('ai-card');
+            }
             card.textContent = player === 2 ? '?' : value;
             card.dataset.index = idx;
             if (player === 1) {


### PR DESCRIPTION
## Summary
- add `ai-card` style and make AI cards appear red in Tactic-21

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68463ef324a08323961a2dc5ea3963ec