### PR TITLE
Add hand size and AI visibility options

### DIFF
--- a/tactic21.html
+++ b/tactic21.html
@@ -26,6 +26,15 @@
             <div><h3>AI</h3><div id="player2Hand" class="hand"></div></div>
         </div>
         <div class="controls">
+            <label for="handSize">Hand Size:</label>
+            <select id="handSize">
+                <option value="3">3</option>
+                <option value="4" selected>4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+            </select>
+            <label for="aiVisible">Show AI cards</label>
+            <input type="checkbox" id="aiVisible">
             <button class="rest" id="restart">Restart</button>
             <button class="baton" id="rulesButton">&#128214; Rules</button>
         </div>
@@ -35,7 +44,7 @@
             <span class="close" onclick="document.getElementById('rulesModal').style.display='none'">&times;</span>
             <h2>Tactic-21 Rules</h2>
             <p><strong>Goal:</strong> Create a line of three cards that sums exactly to 21.</p>
-            <p><strong>Setup:</strong> Each player starts with four random cards drawn from a deck containing four of each value from 1 to 11.</p>
+            <p><strong>Setup:</strong> Each player starts with the number of random cards selected in the settings, drawn from a deck containing four of each value from 1 to 11.</p>
             <p><strong>Turn:</strong> On your turn, select a card from your hand and place it on an empty cell. Draw a new card if the deck still has cards.</p>
             <p><strong>Winning:</strong> You win immediately when you form a horizontal, vertical or diagonal line of your own cards totaling 21. If the board fills without a 21 line, lines totaling 20 are worth 1 point and lines totaling 19 are worth 0.5 points. The higher score wins.</p>
         </div>

--- a/tactic21.js
+++ b/tactic21.js
@@ -6,6 +6,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const restartBtn = document.getElementById('restart');
     const rulesBtn = document.getElementById('rulesButton');
     const rulesModal = document.getElementById('rulesModal');
+    const handSizeEl = document.getElementById('handSize');
+    const aiVisibleEl = document.getElementById('aiVisible');
 
     let board;
     let deck;
@@ -13,6 +15,8 @@ document.addEventListener('DOMContentLoaded', () => {
     let currentPlayer;
     let selectedCardIndex = null;
     let gameOver = false;
+    let handSize = parseInt(handSizeEl.value, 10);
+    let aiCardsVisible = aiVisibleEl.checked;
 
     const LINES = [
         [0, 1, 2], [3, 4, 5], [6, 7, 8], // rows
@@ -42,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function dealHands() {
         hands = {1: [], 2: []};
         for (let p = 1; p <= 2; p++) {
-            for (let i = 0; i < 4; i++) {
+            for (let i = 0; i < handSize; i++) {
                 drawCard(p);
             }
         }
@@ -73,7 +77,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (player === 2) {
                 card.classList.add('ai-card');
             }
-            card.textContent = player === 2 ? '?' : value;
+            card.textContent = (player === 2 && !aiCardsVisible) ? '?' : value;
             card.dataset.index = idx;
             if (player === 1) {
                 card.addEventListener('click', () => {
@@ -219,6 +223,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function restart() {
+        handSize = parseInt(handSizeEl.value, 10);
+        aiCardsVisible = aiVisibleEl.checked;
         initDeck();
         dealHands();
         createBoard();
@@ -233,6 +239,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     restartBtn.addEventListener('click', restart);
+    handSizeEl.addEventListener('change', restart);
+    aiVisibleEl.addEventListener('change', () => {
+        aiCardsVisible = aiVisibleEl.checked;
+        renderHands();
+    });
     rulesBtn.addEventListener('click', () => { rulesModal.style.display = 'flex'; });
     restart();
 });


### PR DESCRIPTION
## Summary
- add configurable hand size and AI visibility to Tactic-21
- update rules text to reflect configurable hand size

## Testing
- `node -c tactic21.js`

------
https://chatgpt.com/codex/tasks/task_e_68463fa3e170832387fee98789346ebb