### PR TITLE
Improve Durak AI difficulty

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -1,0 +1,21 @@
+# Durak Rules
+
+Durak is a classic Russian card game played with a 36‑card deck. The goal is to avoid being the last player holding cards.
+
+## Setup
+1. Shuffle and deal six cards to each player.
+2. Reveal the bottom card of the deck – its suit becomes trump.
+3. Player with the lowest trump begins the attack.
+
+## Turn
+1. **Attack**: Attacker plays one card to the table.
+2. **Defence**: Defender must beat the attacking card with a higher card of the same suit or any trump.
+3. **Resolution**:
+   - If the attack is beaten, cards move to the discard pile and roles rotate.
+   - Otherwise the defender takes all cards on the table and roles stay.
+4. **Refill**: Starting with the attacker, players draw from the deck back up to six cards.
+
+When the deck is empty, hands simply shrink. The last player left with cards is the Durak (fool).
+
+### AI Difficulty
+Select **Easy**, **Normal**, or **Hard** from the dropdown before starting a game.

--- a/css/durak.css
+++ b/css/durak.css
@@ -1,0 +1,48 @@
+.durak-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+}
+.hand {
+    display: flex;
+    margin: 10px 0;
+}
+.table {
+    display: flex;
+    flex-wrap: wrap;
+    min-height: 70px;
+    margin: 10px 0;
+}
+.pair {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-right: 5px;
+}
+.status {
+    height: 24px;
+    margin: 10px 0;
+    font-size: 20px;
+}
+.controls {
+    margin-top: 10px;
+}
+.card {
+    width: 40px;
+    height: 60px;
+    border: 1px solid #000;
+    border-radius: 5px;
+    background-color: white;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-right: 5px;
+    font-size: 18px;
+}
+.card.red { color: red; }
+.card.black { color: black; }
+.card.back {
+    background-color: #21262d;
+    border: 1px solid #555;
+}

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
                 <button class="baton" onclick="location.href='pages/tictactoe.html'">Tic-Tac-Toe</button>
                 <button class="baton" onclick="location.href='pages/game21.html'">21</button>
                 <button class="baton" onclick="location.href='pages/tactic21.html'">Tactic-21</button>
+                <button class="baton" onclick="location.href='pages/durak.html'">Durak</button>
             </div>
         </div>
     </div>

--- a/js/durak.js
+++ b/js/durak.js
@@ -1,0 +1,156 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const playerHandEl = document.getElementById('playerHand');
+    const aiHandEl = document.getElementById('aiHand');
+    const tableEl = document.getElementById('table');
+    const statusEl = document.getElementById('status');
+    const newGameBtn = document.getElementById('newGame');
+    const takeBtn = document.getElementById('take');
+    const difficultyEl = document.getElementById('difficulty');
+
+    let state;
+    let awaitingDefence = false;
+
+    function startGame() {
+        state = DurakEngine.createGame();
+        DurakAI.setDifficulty(difficultyEl ? difficultyEl.value : 'normal');
+        awaitingDefence = false;
+        updateView();
+        statusEl.textContent = state.attacker === 0 ? 'Your attack' : 'AI attacks';
+        if (state.attacker === 1) {
+            setTimeout(aiAttack, 600);
+        }
+    }
+
+    function createCardElement(card, onClick) {
+        const div = document.createElement('div');
+        div.className = 'card ' + ((card.suit === '\u2665' || card.suit === '\u2666') ? 'red' : 'black');
+        div.textContent = card.rank + card.suit;
+        if (onClick) div.addEventListener('click', () => onClick(card));
+        return div;
+    }
+
+    function renderHand(el, hand, hide) {
+        el.innerHTML = '';
+        hand.forEach(c => {
+            if (hide) {
+                const back = document.createElement('div');
+                back.className = 'card back';
+                el.appendChild(back);
+            } else {
+                el.appendChild(createCardElement(c, state.attacker===0 && !awaitingDefence ? playerAttack : playerDefend));
+            }
+        });
+    }
+
+    function renderTable() {
+        tableEl.innerHTML = '';
+        state.table.forEach(p => {
+            const pairDiv = document.createElement('div');
+            pairDiv.className = 'pair';
+            pairDiv.appendChild(createCardElement(p.attack));
+            if (p.defence) pairDiv.appendChild(createCardElement(p.defence));
+            tableEl.appendChild(pairDiv);
+        });
+    }
+
+    function updateView() {
+        renderHand(playerHandEl, state.players[0].hand, false);
+        renderHand(aiHandEl, state.players[1].hand, true);
+        renderTable();
+    }
+
+    function playerAttack(card) {
+        if (state.attacker !== 0 || awaitingDefence) return;
+        const idx = state.players[0].hand.indexOf(card);
+        if (idx === -1) return;
+        state.players[0].hand.splice(idx,1);
+        state.table.push({attack: card});
+        awaitingDefence = true;
+        updateView();
+        setTimeout(()=>aiDefend(card),500);
+    }
+
+    function playerDefend(card) {
+        if (state.defender !== 0 || !awaitingDefence) return;
+        const idx = state.players[0].hand.indexOf(card);
+        if (idx === -1) return;
+        const attackCard = state.table[state.table.length-1].attack;
+        if (!DurakEngine.beats(card, attackCard, state.trump)) return;
+        state.players[0].hand.splice(idx,1);
+        state.table[state.table.length-1].defence = card;
+        awaitingDefence = false;
+        updateView();
+        endTurn(true);
+    }
+
+    function aiAttack() {
+        const card = DurakAI.chooseAttack(state,1);
+        if (!card) { endTurn(true); return; }
+        const idx = state.players[1].hand.indexOf(card);
+        state.players[1].hand.splice(idx,1);
+        state.table.push({attack: card});
+        awaitingDefence = true;
+        updateView();
+        statusEl.textContent = 'Defend!';
+    }
+
+    function aiDefend(attackCard) {
+        const card = DurakAI.chooseDefence(state, attackCard, 1);
+        if (!card) {
+            // AI picks up
+            state.players[1].hand.push(attackCard);
+            state.table = [];
+            awaitingDefence = false;
+            DurakEngine.draw(state,0);
+            DurakEngine.draw(state,1);
+            statusEl.textContent = 'AI picked up';
+            DurakEngine.rotateRoles(state,false);
+            updateView();
+            if (state.attacker === 1) setTimeout(aiAttack,600);
+            return;
+        }
+        const idx = state.players[1].hand.indexOf(card);
+        state.players[1].hand.splice(idx,1);
+        state.table[0].defence = card;
+        awaitingDefence = false;
+        updateView();
+        endTurn(true);
+    }
+
+    function endTurn(success) {
+        DurakEngine.endTurn(state, success);
+        updateView();
+        if (state.players[0].hand.length === 0 && state.stock.length === 0) {
+            statusEl.textContent = 'You win!';
+            return;
+        }
+        if (state.players[1].hand.length === 0 && state.stock.length === 0) {
+            statusEl.textContent = 'AI wins!';
+            return;
+        }
+        statusEl.textContent = state.attacker === 0 ? 'Your attack' : 'AI attacks';
+        if (state.attacker === 1) setTimeout(aiAttack,600);
+    }
+
+    takeBtn.addEventListener('click', () => {
+        if (state.defender !== 0 || !awaitingDefence) return;
+        state.players[0].hand.push(state.table[0].attack);
+        if (state.table[0].defence) state.players[0].hand.push(state.table[0].defence);
+        state.table = [];
+        awaitingDefence = false;
+        DurakEngine.draw(state,0);
+        DurakEngine.draw(state,1);
+        DurakEngine.rotateRoles(state,false);
+        updateView();
+        statusEl.textContent = 'You picked up';
+        if (state.attacker === 1) setTimeout(aiAttack,600);
+    });
+
+    newGameBtn.addEventListener('click', startGame);
+    if (difficultyEl) {
+        difficultyEl.addEventListener('change', () => {
+            DurakAI.setDifficulty(difficultyEl.value);
+        });
+    }
+    startGame();
+});

--- a/js/durakAI.js
+++ b/js/durakAI.js
@@ -1,0 +1,52 @@
+const DurakAI = (() => {
+    let difficulty = 'normal';
+
+    function setDifficulty(level) {
+        difficulty = level || 'normal';
+    }
+
+    function chooseAttack(state, playerIndex) {
+        const hand = state.players[playerIndex].hand;
+        const options = DurakEngine.getLegalAttacks(hand, state.table);
+        if (options.length === 0) return null;
+        options.sort((a,b)=>rankValue(a,state.trump)-rankValue(b,state.trump));
+
+        if (difficulty === 'easy') {
+            if (Math.random() < 0.7) return options[0];
+            return options[Math.floor(Math.random()*options.length)];
+        }
+
+        if (difficulty === 'hard') {
+            const nonTrump = options.filter(c => c.suit !== state.trump);
+            if (nonTrump.length > 0) return nonTrump[0];
+        }
+
+        return options[0];
+    }
+
+    function chooseDefence(state, cardToBeat, playerIndex) {
+        const hand = state.players[playerIndex].hand;
+        const options = DurakEngine.getLegalDefences(cardToBeat, hand, state.trump);
+        if (options.length === 0) return null;
+        options.sort((a,b)=>rankValue(a,state.trump)-rankValue(b,state.trump));
+
+        if (difficulty === 'easy') {
+            if (Math.random() < 0.7) return options[0];
+            return options[Math.floor(Math.random()*options.length)];
+        }
+
+        if (difficulty === 'hard') {
+            const sameSuit = options.filter(c => c.suit === cardToBeat.suit);
+            if (sameSuit.length > 0) return sameSuit[0];
+        }
+
+        return options[0];
+    }
+
+    function rankValue(card, trump) {
+        const ranks = ['6','7','8','9','10','J','Q','K','A'];
+        return ranks.indexOf(card.rank) + (card.suit === trump ? 100 : 0);
+    }
+
+    return { chooseAttack, chooseDefence, setDifficulty };
+})();

--- a/js/durakEngine.js
+++ b/js/durakEngine.js
@@ -1,0 +1,103 @@
+const DurakEngine = (() => {
+    const ranks = ['6','7','8','9','10','J','Q','K','A'];
+    const suits = ['\u2660','\u2665','\u2666','\u2663'];
+
+    function createDeck() {
+        const deck = [];
+        for (const suit of suits) {
+            for (const rank of ranks) {
+                deck.push({rank, suit});
+            }
+        }
+        return deck;
+    }
+
+    function shuffle(array) {
+        for (let i = array.length - 1; i > 0; i--) {
+            const j = Math.floor(Math.random() * (i + 1));
+            [array[i], array[j]] = [array[j], array[i]];
+        }
+    }
+
+    function deal(deck, count) {
+        return deck.splice(0, count);
+    }
+
+    function beats(card, target, trump) {
+        if (card.suit === target.suit && rankIndex(card) > rankIndex(target)) return true;
+        if (card.suit === trump && target.suit !== trump) return true;
+        if (card.suit === trump && target.suit === trump && rankIndex(card) > rankIndex(target)) return true;
+        return false;
+    }
+
+    function rankIndex(card) {
+        return ranks.indexOf(card.rank);
+    }
+
+    function getLegalDefences(cardToBeat, hand, trump) {
+        return hand.filter(c => beats(c, cardToBeat, trump));
+    }
+
+    function getLegalAttacks(hand, table) {
+        if (table.length === 0) return hand.slice();
+        const ranksOnTable = new Set();
+        table.forEach(p => {
+            ranksOnTable.add(p.attack.rank);
+            if (p.defence) ranksOnTable.add(p.defence.rank);
+        });
+        return hand.filter(c => ranksOnTable.has(c.rank));
+    }
+
+    function createGame() {
+        const deck = createDeck();
+        shuffle(deck);
+        const players = [{id:0, hand:deal(deck,6)}, {id:1, hand:deal(deck,6)}];
+        const trump = deck[deck.length - 1].suit;
+        return {
+            players,
+            stock: deck,
+            trump,
+            table: [],
+            attacker: 0,
+            defender: 1,
+            discard: []
+        };
+    }
+
+    function draw(state, playerIndex) {
+        while (state.players[playerIndex].hand.length < 6 && state.stock.length > 0) {
+            state.players[playerIndex].hand.push(state.stock.shift());
+        }
+    }
+
+    function rotateRoles(state, successfulDefence) {
+        if (successfulDefence) {
+            const a = state.attacker;
+            state.attacker = state.defender;
+            state.defender = (a + 1) % state.players.length;
+        } else {
+            state.attacker = state.attacker;
+            state.defender = (state.defender + 1) % state.players.length;
+        }
+    }
+
+    function endTurn(state, successfulDefence) {
+        if (successfulDefence) {
+            state.discard.push(...state.table.flatMap(p => [p.attack, p.defence]));
+        } else {
+            state.players[state.defender].hand.push(...state.table.flatMap(p => [p.attack].concat(p.defence ? [p.defence] : [])));
+        }
+        state.table = [];
+        draw(state, state.attacker);
+        draw(state, state.defender);
+        rotateRoles(state, successfulDefence);
+    }
+
+    return {
+        createGame,
+        getLegalDefences,
+        getLegalAttacks,
+        beats,
+        endTurn
+    };
+})();

--- a/pages/durak.html
+++ b/pages/durak.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Durak</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/durak.css">
+    <script src="../js/durakEngine.js"></script>
+    <script src="../js/durakAI.js"></script>
+    <script src="../js/durak.js" defer></script>
+</head>
+<body>
+    <div class="nav-bar">
+        <div class="logo-container">
+            <div class="logo"></div>
+        </div>
+        <div class="bank-name" onclick="location.href='../index.html'">Galactic Reserve</div>
+        <div class="nav-item" onclick="location.href='../index.html'">Back to the Strategies</div>
+    </div>
+    <div class="durak-container">
+        <h1>Durak</h1>
+        <div id="aiHand" class="hand"></div>
+        <div id="table" class="table"></div>
+        <div id="playerHand" class="hand"></div>
+        <div id="status" class="status"></div>
+        <div class="controls">
+            <label for="difficulty">AI:</label>
+            <select id="difficulty">
+                <option value="hard">Hard</option>
+                <option value="normal" selected>Normal</option>
+                <option value="easy">Easy</option>
+            </select>
+            <button class="baton" id="newGame">New Game</button>
+            <button class="baton" id="take">Take</button>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add selectable AI difficulty for Durak
- implement easy, normal and hard heuristics
- expose difficulty dropdown in Durak page
- mention difficulty in rules

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846f01a3b648323af6a6826dd181972