### PR TITLE
Fix AI defense display and trump card endgame check

### DIFF
--- a/js/durak.js
+++ b/js/durak.js
@@ -136,17 +136,17 @@ document.addEventListener('DOMContentLoaded', () => {
         state.table[0].defence = card;
         awaitingDefence = false;
         updateView();
-        endTurn(true);
+        setTimeout(() => endTurn(true), 500);
     }
 
     function endTurn(success) {
         DurakEngine.endTurn(state, success);
         updateView();
-        if (state.players[0].hand.length === 0 && state.stock.length === 0) {
+        if (state.players[0].hand.length === 0 && state.stock.length === 0 && !state.trumpCard) {
             statusEl.textContent = 'You win!';
             return;
         }
-        if (state.players[1].hand.length === 0 && state.stock.length === 0) {
+        if (state.players[1].hand.length === 0 && state.stock.length === 0 && !state.trumpCard) {
             statusEl.textContent = 'AI wins!';
             return;
         }


### PR DESCRIPTION
## Summary
- show AI's defending card for 0.5 seconds before clearing the table
- include the trump card when checking for game end conditions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846f9fe15008323bf48b7ab1b99077d