### PR TITLE
Display trump suit when deck empty

### DIFF
--- a/css/durak.css
+++ b/css/durak.css
@@ -26,6 +26,9 @@
 .trump-card {
     margin-left: 10px;
 }
+.trump-indicator {
+    margin-left: 10px;
+}
 .pair {
     display: flex;
     flex-direction: column;

--- a/js/durak.js
+++ b/js/durak.js
@@ -71,6 +71,10 @@ document.addEventListener('DOMContentLoaded', () => {
                 trumpEl.classList.add('trump-card');
                 stockEl.appendChild(trumpEl);
             }
+        } else {
+            const indicator = createCardElement({rank: '', suit: state.trump});
+            indicator.classList.add('trump-indicator');
+            stockEl.appendChild(indicator);
         }
     }
 


### PR DESCRIPTION
## Summary
- add `trump-indicator` style in CSS
- show trump suit indicator when no cards remain in stock

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846fcbee1508323a0a77bc0c9fa590f