### PR TITLE
Fix win detection after pickup

### DIFF
--- a/js/durak.js
+++ b/js/durak.js
@@ -127,10 +127,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!card) {
             // AI picks up
             awaitingDefence = false;
-            DurakEngine.endTurn(state, false);
-            updateView();
             statusEl.textContent = 'AI picked up';
-            if (state.attacker === 1) setTimeout(aiAttack,600);
+            setTimeout(() => endTurn(false), 600);
             return;
         }
         const idx = state.players[1].hand.indexOf(card);
@@ -159,10 +157,8 @@ document.addEventListener('DOMContentLoaded', () => {
     takeBtn.addEventListener('click', () => {
         if (state.defender !== 0 || !awaitingDefence) return;
         awaitingDefence = false;
-        DurakEngine.endTurn(state, false);
-        updateView();
         statusEl.textContent = 'You picked up';
-        if (state.attacker === 1) setTimeout(aiAttack, 600);
+        setTimeout(() => endTurn(false), 600);
     });
 
     newGameBtn.addEventListener('click', startGame);


### PR DESCRIPTION
## Summary
- fix winner check when either side picks up by ensuring the main endTurn logic is run

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6846ffc7d2248323b82af757d6d2bb51