### PR TITLE
Implement throwing and beaten mechanics

### DIFF
--- a/pages/durak.html
+++ b/pages/durak.html
@@ -35,6 +35,7 @@
             </select>
             <button class="baton" id="newGame">New Game</button>
             <button class="baton" id="take">Take</button>
+            <button class="baton" id="beat">Beaten</button>
             <button class="baton" id="rulesButton">&#128214; Rules</button>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add "Beaten" control button to Durak page
- allow multiple attacks with throw-in rules
- update AI to handle repeated attacks and conclude with beaten
- expose beaten button only when human attacks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68470710fcd4832390659aaf1f3cc292