### PR TITLE
Implement dynamic attack limit

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -12,9 +12,9 @@ The player holding the lowest trump begins the first attack. The player to their
 Cards are ranked 6, 7, 8, 9, 10, J, Q, K, A (ace high). Any trump beats every card of the other suits. The attacker plays one card face up on the table. The defender must beat it either with a higher card of the same suit or with any trump card.
 
 ### Continuing the Attack
-If the defender succeeds, the attacker (or other players in clockwise order) may add new attacking cards. Each new card must match the rank of any card already on the table. No more than six attacking cards may be played in a round. The defender must beat each new card in the same fashion.
+If the defender succeeds, the attacker (or other players in clockwise order) may add new attacking cards. Each new card must match the rank of any card already on the table. Before any cards have been successfully discarded, no more than five attacking cards may be played. After the first discard, the limit increases to six. The defender must beat each new card in the same fashion.
 
-A defender who cannot or chooses not to beat the current attack must pick up all cards on the table. After the defender picks up, other players may add cards matching any rank already played, up to the six card limit.
+A defender who cannot or chooses not to beat the current attack must pick up all cards on the table. After the defender picks up, other players may add cards matching any rank already played, up to the current attack limit.
 
 If the defender beats all attacking cards and no one adds more, all cards from that round go to the discard pile and the defender becomes the next attacker.
 

--- a/js/durak.js
+++ b/js/durak.js
@@ -110,7 +110,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (state.attacker !== 0 || awaitingDefence) return;
         const legal = DurakEngine.getLegalAttacks(state.players[0].hand, state.table);
         if (!legal.includes(card)) return;
-        if (state.table.length >= 6 || state.table.length >= state.players[1].hand.length) return;
+        const maxPairs = DurakEngine.getAttackLimit(state);
+        if (state.table.length >= maxPairs || state.table.length >= state.players[1].hand.length) return;
         const idx = state.players[0].hand.indexOf(card);
         if (idx === -1) return;
         state.players[0].hand.splice(idx,1);
@@ -134,7 +135,8 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function aiAttack() {
-        if (state.table.length >= 6 || state.table.length >= state.players[0].hand.length) {
+        const maxPairs = DurakEngine.getAttackLimit(state);
+        if (state.table.length >= maxPairs || state.table.length >= state.players[0].hand.length) {
             endTurn(true);
             return;
         }

--- a/js/durakEngine.js
+++ b/js/durakEngine.js
@@ -130,11 +130,16 @@ const DurakEngine = (() => {
         rotateRoles(state, successfulDefence);
     }
 
+    function getAttackLimit(state) {
+        return state.discard.length === 0 ? 5 : 6;
+    }
+
     return {
         createGame,
         getLegalDefences,
         getLegalAttacks,
         beats,
-        endTurn
+        endTurn,
+        getAttackLimit
     };
 })();

--- a/pages/durak.html
+++ b/pages/durak.html
@@ -51,8 +51,8 @@
             <h4>First Attack</h4>
             <p>Cards are ranked 6, 7, 8, 9, 10, J, Q, K, A (ace high). Any trump beats every card of the other suits. The attacker plays one card face up on the table. The defender must beat it either with a higher card of the same suit or with any trump card.</p>
             <h4>Continuing the Attack</h4>
-            <p>If the defender succeeds, the attacker (or other players in clockwise order) may add new attacking cards. Each new card must match the rank of any card already on the table. No more than six attacking cards may be played in a round. The defender must beat each new card in the same fashion.</p>
-            <p>A defender who cannot or chooses not to beat the current attack must pick up all cards on the table. After the defender picks up, other players may add cards matching any rank already played, up to the six card limit.</p>
+            <p>If the defender succeeds, the attacker (or other players in clockwise order) may add new attacking cards. Each new card must match the rank of any card already on the table. Before any cards have been successfully discarded, the attack is limited to five cards. After the first discard, the limit increases to six. The defender must beat each new card in the same fashion.</p>
+            <p>A defender who cannot or chooses not to beat the current attack must pick up all cards on the table. After the defender picks up, other players may add cards matching any rank already played, up to the current attack limit.</p>
             <p>If the defender beats all attacking cards and no one adds more, all cards from that round go to the discard pile and the defender becomes the next attacker.</p>
             <p>No one may look through the discard pile during play.</p>
             <h4>End of Turn</h4>


### PR DESCRIPTION
## Summary
- restrict number of attacking cards to 5 until the first discard, then allow 6
- update Durak engine and front-end logic to respect new limit
- document new rule in the markdown rules and on the Durak page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847092bd59c832387aded6d2be89f39