### PR TITLE
Fix attack limit based on defender's starting hand

### DIFF
--- a/Rules.md
+++ b/Rules.md
@@ -12,7 +12,7 @@ The player holding the lowest trump begins the first attack. The player to their
 Cards are ranked 6, 7, 8, 9, 10, J, Q, K, A (ace high). Any trump beats every card of the other suits. The attacker plays one card face up on the table. The defender must beat it either with a higher card of the same suit or with any trump card.
 
 ### Continuing the Attack
-If the defender succeeds, the attacker (or other players in clockwise order) may add new attacking cards. Each new card must match the rank of any card already on the table. Before any cards have been successfully discarded, no more than five attacking cards may be played. After the first discard, the limit increases to six. The defender must beat each new card in the same fashion.
+If the defender succeeds, the attacker (or other players in clockwise order) may add new attacking cards. Each new card must match the rank of any card already on the table. The total number of attacking cards may never exceed the number of cards that the defender had when the attack began. Before any cards have been successfully discarded, no more than five attacking cards may be played. After the first discard, the limit increases to six. The defender must beat each new card in the same fashion.
 
 A defender who cannot or chooses not to beat the current attack must pick up all cards on the table. After the defender picks up, other players may add cards matching any rank already played, up to the current attack limit.
 

--- a/js/durak.js
+++ b/js/durak.js
@@ -111,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const legal = DurakEngine.getLegalAttacks(state.players[0].hand, state.table);
         if (!legal.includes(card)) return;
         const maxPairs = DurakEngine.getAttackLimit(state);
-        if (state.table.length >= maxPairs || state.table.length >= state.players[1].hand.length) return;
+        if (state.table.length >= maxPairs || state.table.length >= state.defenderStartHandSize) return;
         const idx = state.players[0].hand.indexOf(card);
         if (idx === -1) return;
         state.players[0].hand.splice(idx,1);
@@ -136,7 +136,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     function aiAttack() {
         const maxPairs = DurakEngine.getAttackLimit(state);
-        if (state.table.length >= maxPairs || state.table.length >= state.players[0].hand.length) {
+        if (state.table.length >= maxPairs || state.table.length >= state.defenderStartHandSize) {
             endTurn(true);
             return;
         }

--- a/js/durakEngine.js
+++ b/js/durakEngine.js
@@ -77,7 +77,8 @@ const DurakEngine = (() => {
             table: [],
             attacker,
             defender,
-            discard: []
+            discard: [],
+            defenderStartHandSize: players[defender].hand.length
         };
     }
 
@@ -128,6 +129,7 @@ const DurakEngine = (() => {
         state.table = [];
         refillPlayers(state);
         rotateRoles(state, successfulDefence);
+        state.defenderStartHandSize = state.players[state.defender].hand.length;
     }
 
     function getAttackLimit(state) {

--- a/pages/durak.html
+++ b/pages/durak.html
@@ -51,7 +51,7 @@
             <h4>First Attack</h4>
             <p>Cards are ranked 6, 7, 8, 9, 10, J, Q, K, A (ace high). Any trump beats every card of the other suits. The attacker plays one card face up on the table. The defender must beat it either with a higher card of the same suit or with any trump card.</p>
             <h4>Continuing the Attack</h4>
-            <p>If the defender succeeds, the attacker (or other players in clockwise order) may add new attacking cards. Each new card must match the rank of any card already on the table. Before any cards have been successfully discarded, the attack is limited to five cards. After the first discard, the limit increases to six. The defender must beat each new card in the same fashion.</p>
+            <p>If the defender succeeds, the attacker (or other players in clockwise order) may add new attacking cards. Each new card must match the rank of any card already on the table. The number of attacking cards may never exceed the defender's hand size at the start of the attack. Before any cards have been successfully discarded, the attack is limited to five cards. After the first discard, the limit increases to six. The defender must beat each new card in the same fashion.</p>
             <p>A defender who cannot or chooses not to beat the current attack must pick up all cards on the table. After the defender picks up, other players may add cards matching any rank already played, up to the current attack limit.</p>
             <p>If the defender beats all attacking cards and no one adds more, all cards from that round go to the discard pile and the defender becomes the next attacker.</p>
             <p>No one may look through the discard pile during play.</p>


### PR DESCRIPTION
## Summary
- track defender's hand size at start of turn
- limit additional attacks using this stored value
- document rule on attack limit relative to defender's starting hand

## Testing
- `node --check js/durakEngine.js`
- `node --check js/durak.js`


------
https://chatgpt.com/codex/tasks/task_e_684715492c248323b0279103b09a79ec