### PR TITLE
Auto-end durak round when AI empties hand

### DIFF
--- a/js/durak.js
+++ b/js/durak.js
@@ -165,6 +165,16 @@ document.addEventListener('DOMContentLoaded', () => {
         awaitingDefence = false;
         updateView();
         statusEl.textContent = 'Your attack';
+        // Automatically end the round if the AI has no cards left, the deck is
+        // empty, and the player cannot legally continue the attack. Without
+        // this check the status would misleadingly remain "Your attack" even
+        // though the AI has effectively won.
+        if (state.players[1].hand.length === 0 && state.stock.length === 0 && !state.trumpCard) {
+            const legal = DurakEngine.getLegalAttacks(state.players[0].hand, state.table);
+            if (legal.length === 0) {
+                setTimeout(() => endTurn(true), 300);
+            }
+        }
     }
 
     function endTurn(success) {


### PR DESCRIPTION
## Summary
- detect when the AI has no cards and no draw pile
- automatically finish the turn and declare victory if the player cannot continue

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684719ce35cc8323be7eeb515158cac7