### PR TITLE
Fix falling animation after cheat win

### DIFF
--- a/js/tictactoe.js
+++ b/js/tictactoe.js
@@ -138,6 +138,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (result) {
                         statusEl.textContent = result === 'draw' ? 'Draw!' : `${result} wins!`;
                         gameOver = true;
+                        if (result === aiSymbol) {
+                            explodeBoard();
+                        }
                     }
                     return true;
                 }


### PR DESCRIPTION
## Summary
- trigger falling animation when the AI wins by cheating

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68471f0ffc2c832380e94b7259f80f65