### PR TITLE
Add play-or-keep prompt for drawn UNO cards

### DIFF
--- a/css/uno.css
+++ b/css/uno.css
@@ -67,3 +67,35 @@
     cursor: pointer;
     font-size: 0;
 }
+
+.draw-select {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.draw-select.hidden {
+    display: none;
+}
+
+.draw-select .card {
+    width: 60px;
+    height: 90px;
+    margin: 10px;
+    cursor: pointer;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 16px;
+}
+
+.draw-select .drawn-card {
+    cursor: default;
+}

--- a/js/uno.js
+++ b/js/uno.js
@@ -8,6 +8,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const newGameBtn = document.getElementById('newGame');
     const drawBtn = document.getElementById('draw');
     const colorSelectEl = document.getElementById('colorSelect');
+    const drawSelectEl = document.getElementById('drawSelect');
 
     let deck = [];
     let discardPile = [];
@@ -132,6 +133,23 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function promptPlay(card) {
+        return new Promise(resolve => {
+            const cardEl = drawSelectEl.querySelector('.drawn-card');
+            cardEl.className = 'card drawn-card ' + card.color;
+            cardEl.textContent = displayValue(card);
+            drawSelectEl.classList.remove('hidden');
+            const options = drawSelectEl.querySelectorAll('.option');
+            function choose(e) {
+                const play = e.currentTarget.dataset.choice === 'yes';
+                options.forEach(o => o.removeEventListener('click', choose));
+                drawSelectEl.classList.add('hidden');
+                resolve(play);
+            }
+            options.forEach(o => o.addEventListener('click', choose));
+        });
+    }
+
     function chooseColorAI() {
         const counts = {red:0,green:0,blue:0,yellow:0};
         aiHand.forEach(c => { if (c.color !== 'wild') counts[c.color]++; });
@@ -193,7 +211,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const card = drawCard(playerHand);
         updateView();
         if (isPlayable(card)) {
-            const play = confirm(`Play drawn card ${displayValue(card)}?`);
+            const play = await promptPlay(card);
             if (play) {
                 await playerPlay(playerHand.length - 1);
             } else {

--- a/pages/uno.html
+++ b/pages/uno.html
@@ -38,5 +38,10 @@
         <div class="card blue" data-color="blue"></div>
         <div class="card yellow" data-color="yellow"></div>
     </div>
+    <div id="drawSelect" class="draw-select hidden">
+        <div class="card drawn-card"></div>
+        <div class="card green option" data-choice="yes">Play</div>
+        <div class="card red option" data-choice="no">Keep</div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add overlay prompt to choose whether to play a drawn card
- implement `promptPlay` in UNO script
- style draw prompt overlay
- update UNO page with new overlay

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68476206e77083239c7501d2214435b7