### PR TITLE
Update UNO play-or-keep UI

### DIFF
--- a/css/uno.css
+++ b/css/uno.css
@@ -76,6 +76,7 @@
     height: 100%;
     background: rgba(0, 0, 0, 0.8);
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
     z-index: 1000;
@@ -98,4 +99,15 @@
 
 .draw-select .drawn-card {
     cursor: default;
+}
+
+.draw-select .options {
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+}
+
+.card.black {
+    background-color: #000;
+    color: white;
 }

--- a/pages/uno.html
+++ b/pages/uno.html
@@ -40,8 +40,10 @@
     </div>
     <div id="drawSelect" class="draw-select hidden">
         <div class="card drawn-card"></div>
-        <div class="card green option" data-choice="yes">Play</div>
-        <div class="card red option" data-choice="no">Keep</div>
+        <div class="options">
+            <div class="card option black" data-choice="yes">Play</div>
+            <div class="card option black" data-choice="no">Keep</div>
+        </div>
     </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restyle draw menu in UNO
- position play/keep options underneath drawn card

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684763b0b9fc8323805efd54c76e0e18