### PR TITLE
Update UNO stack UI

### DIFF
--- a/css/uno.css
+++ b/css/uno.css
@@ -146,3 +146,7 @@
     justify-content: center;
     margin-top: 10px;
 }
+
+.stack-select .take-option {
+    margin-top: 10px;
+}

--- a/js/uno.js
+++ b/js/uno.js
@@ -168,17 +168,18 @@ document.addEventListener('DOMContentLoaded', () => {
                 container.appendChild(div);
             });
             const take = document.createElement('div');
-            take.className = 'card black';
+            take.className = 'card black take-option';
             take.textContent = 'Take +' + total;
             take.addEventListener('click', () => {
                 cleanup();
                 resolve(null);
             });
-            container.appendChild(take);
+            stackSelectEl.appendChild(take);
             stackSelectEl.classList.remove('hidden');
             function cleanup() {
                 stackSelectEl.classList.add('hidden');
                 container.innerHTML = '';
+                stackSelectEl.removeChild(take);
             }
         });
     }


### PR DESCRIPTION
## Summary
- adjust stack-select JS logic to append the 'Take +N' card underneath stackable cards
- add CSS rule so 'Take +N' appears below the stack options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68476bf7dfb8832392f54b3ae849c74e