### PR TITLE
Fix UNO zero card play

### DIFF
--- a/js/uno.js
+++ b/js/uno.js
@@ -205,7 +205,7 @@ document.addEventListener('DOMContentLoaded', () => {
             skipNext = true;
         } else {
             currentColor = card.color;
-            currentValue = card.value || null;
+            currentValue = (card.value !== undefined) ? card.value : null;
             currentType = card.type;
             if (card.type === 'draw2') {
                 pendingDraw += 2;
@@ -401,7 +401,7 @@ document.addEventListener('DOMContentLoaded', () => {
             first = drawCard(discardPile);
         } while (first.color === 'wild');
         currentColor = first.color;
-        currentValue = first.value || null;
+        currentValue = (first.value !== undefined) ? first.value : null;
         currentType = first.type;
         updateDiscard();
         currentPlayer = 'player';


### PR DESCRIPTION
## Summary
- ensure UNO game properly handles 0 value cards when updating game state

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68484e2aabf88323ae18c399029006f9