### PR TITLE
Add CLI and documentation for Buckshot Roulette

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Galactic Reserve Games
+
+This project contains several mini games implemented for the Galactic Reserve site.
+The **Buckshot Roulette** directory includes a simple Node based implementation
+used in the repository tests.
+
+## Running the tests
+
+```
+npm test
+```
+
+## Buckshot Roulette CLI
+
+A minimal text interface is provided to play Buckshot Roulette against a basic
+AI.
+
+```
+node buckshot-cli.js
+```
+
+During the game the CLI prints current HP, remaining shell counts and your
+inventory. Commands allow you to `shoot`, `use <index>` to apply an item,
+`save <file>` or `load <file>` and `quit`.
+
+## Game State Flow
+
+```mermaid
+stateDiagram-v2
+    ITEMS --> HEALTH
+    HEALTH --> LOAD
+    LOAD --> MAIN
+    MAIN --> ITEMS : magazine empty
+```

--- a/buckshot-cli.js
+++ b/buckshot-cli.js
@@ -1,0 +1,99 @@
+// Buckshot Roulette minimal CLI
+const readline = require('readline');
+const {
+  GameState, Shotgun, ShellType, Phase,
+  setRoundHp, loadShotgun,
+  saveState, loadState,
+  CigarettePack, Beer, MagnifyingGlass, Handcuffs, Handsaw,
+  dealerUseItems
+} = require('./js/buckshotCore');
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+function ask(q) { return new Promise(res => rl.question(q, res)); }
+
+function startRound(state) {
+  setRoundHp(state);
+  loadShotgun(state);
+  state.turnOrder = [0,1];
+  state.turn = 0;
+  state.players[0].items = state.players[0].items || [];
+  state.players[1].items = state.players[1].items || [];
+}
+
+function printStatus(state) {
+  const p1 = state.players[0];
+  const p2 = state.players[1];
+  console.log(`You HP: ${p1.hp}/${p1.hpMax}`);
+  console.log(`Dealer HP: ${p2.hp}/${p2.hpMax}`);
+  const live = state.shotgun.magazine.filter(s => s.type === ShellType.LIVE).length;
+  const blank = state.shotgun.magazine.filter(s => s.type === ShellType.BLANK).length;
+  console.log(`Magazine -> live:${live} blank:${blank}`);
+  console.log('Inventory:', (p1.items||[]).map((it,i)=>`${i}:${it.constructor.name}`).join(' ')||'none');
+}
+
+function getOpponent(state, idx) {
+  return state.players[(idx+1)%2];
+}
+
+async function humanTurn(state) {
+  const player = state.players[0];
+  printStatus(state);
+  const input = await ask('Command (shoot/use N/save F/load F/quit)> ');
+  const [cmd,arg] = input.trim().split(/\s+/);
+  if (cmd === 'quit') return false;
+  if (cmd === 'save') { saveState(state, arg || 'save.json'); console.log('Saved'); return true; }
+  if (cmd === 'load') { Object.assign(state, loadState(arg || 'save.json')); console.log('Loaded'); return true; }
+  if (cmd === 'use') {
+    const idx = parseInt(arg,10);
+    if (!isNaN(idx) && player.items && player.items[idx]) {
+      const [item] = player.items.splice(idx,1);
+      item.apply(state, player);
+    } else {
+      console.log('No such item');
+    }
+    return true;
+  }
+  // default shoot
+  state.takeTurn(player);
+  return true;
+}
+
+function aiTurn(state) {
+  dealerUseItems(state);
+  state.takeTurn(state.players[1]);
+  console.log('Dealer takes a turn.');
+}
+
+function roundWinner(state) {
+  const p1 = state.players[0];
+  const p2 = state.players[1];
+  if (p1.hp <=0 && p2.hp <=0) return null;
+  if (p1.hp <=0) return p2;
+  if (p2.hp <=0) return p1;
+  if (!state.shotgun.magazine.length) return p1.hp >= p2.hp ? p1 : p2;
+  return null;
+}
+
+async function main() {
+  let state = new GameState({ players:[{name:'You', items:[new CigarettePack(), new Beer()]},{name:'Dealer', items:[new MagnifyingGlass()]}], shotgun:new Shotgun() });
+  startRound(state);
+  while (!state.finished) {
+    if (state.turn === 0) {
+      const cont = await humanTurn(state);
+      if (!cont) break;
+    } else {
+      aiTurn(state);
+    }
+    const winner = roundWinner(state);
+    if (winner) {
+      console.log(`Round winner: ${winner.name}`);
+      state.resolveRound(winner);
+      if (state.finished) break;
+      startRound(state);
+    }
+  }
+  console.log('Game over!');
+  rl.close();
+}
+
+main();

--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -1,0 +1,17 @@
+.buckshot-container {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-top: 20px;
+}
+.game-area {
+    margin: 10px 0;
+}
+.status {
+    height: 24px;
+    margin: 10px 0;
+    font-size: 20px;
+}
+.controls {
+    margin-top: 10px;
+}

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
                 <button class="baton" onclick="location.href='pages/tactic21.html'">Tactic-21</button>
                 <button class="baton" onclick="location.href='pages/durak.html'">Durak</button>
                 <button class="baton" onclick="location.href='pages/uno.html'">UNO</button>
+                <button class="baton" onclick="location.href='pages/buckshot.html'">Buckshot Roulette</button>
             </div>
         </div>
     </div>

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', () => {
+    // Game logic will be implemented in a future update
+});

--- a/js/buckshotCore.js
+++ b/js/buckshotCore.js
@@ -1,0 +1,538 @@
+/**
+ * Buckshot Roulette core logic
+ * @module buckshotCore
+ */
+
+/**
+ * Types of shotgun shells.
+ * @readonly
+ * @enum {string}
+ */
+const ShellType = Object.freeze({
+    LIVE: 'LIVE',
+    BLANK: 'BLANK'
+});
+
+/**
+ * Shotgun shell data structure.
+ * @class
+ */
+class Shell {
+    /**
+     * @param {ShellType} [type=ShellType.BLANK] shell type
+     */
+    constructor(type = ShellType.BLANK) {
+        /** @type {ShellType} */
+        this.type = type;
+    }
+}
+
+/**
+ * Shotgun container with magazine.
+ * @class
+ */
+class Shotgun {
+    constructor() {
+        /** @type {Shell[]} */
+        this.magazine = [];
+        /** @type {boolean} indicates double damage for next live shell */
+        this.barrelMod = false;
+    }
+}
+
+/**
+ * Game phases.
+ * @readonly
+ * @enum {string}
+ */
+const Phase = Object.freeze({
+    ITEMS: 'ITEMS',
+    HEALTH: 'HEALTH',
+    LOAD: 'LOAD',
+    MAIN: 'MAIN'
+});
+
+/**
+ * Encapsulates the full game state.
+ * @class
+ */
+class GameState {
+    /**
+     * @param {Object} param0 initial data
+     * @param {Phase} [param0.phase]
+     * @param {number} [param0.round]
+     * @param {number} [param0.turn]
+     * @param {Object[]} [param0.players]
+     * @param {Shotgun} [param0.shotgun]
+     * @param {Function} [param0.rng]
+     * @param {number} [param0.streak]
+     * @param {boolean} [param0.finished]
+     * @param {number} [param0.bank]
+     * @param {number[]} [param0.turnOrder]
+     */
+    constructor({
+        phase = Phase.ITEMS,
+        round = 1,
+        turn = 0,
+        players = [],
+        shotgun = new Shotgun(),
+        rng = 0,
+        streak = 0,
+        finished = false,
+        bank = 0,
+        turnOrder = null
+    } = {}) {
+        this.phase = phase;
+        this.round = round;
+        this.turn = turn;
+        this.players = players;
+        this.shotgun = shotgun;
+        this.rng = rng;
+        this.streak = streak;
+        this.finished = finished;
+        this.bank = bank;
+        this.turnOrder = Array.isArray(turnOrder) ? turnOrder.slice() : null;
+    }
+
+    /**
+     * Serialize state to a plain object.
+     * @returns {Object}
+     */
+    toJSON() {
+        return {
+            phase: this.phase,
+            round: this.round,
+            turn: this.turn,
+            players: this.players,
+            shotgun: {
+                magazine: this.shotgun.magazine.map(s => ({ type: s.type })),
+                barrelMod: this.shotgun.barrelMod
+            },
+            rng: this.rng,
+            streak: this.streak,
+            finished: this.finished,
+            bank: this.bank,
+            turnOrder: this.turnOrder
+        };
+    }
+
+    /**
+     * Restore GameState from serialized data.
+     * @param {Object|string} obj JSON or object
+     * @returns {GameState}
+     */
+    static fromJSON(obj) {
+        if (typeof obj === 'string') {
+            obj = JSON.parse(obj);
+        }
+        const state = new GameState();
+        state.phase = obj.phase;
+        state.round = obj.round;
+        state.turn = obj.turn;
+        state.players = obj.players;
+        state.shotgun = new Shotgun();
+        if (obj.shotgun) {
+            state.shotgun.magazine = (obj.shotgun.magazine || []).map(s => new Shell(s.type));
+            state.shotgun.barrelMod = !!obj.shotgun.barrelMod;
+        }
+        state.rng = obj.rng;
+        state.streak = obj.streak;
+        state.finished = obj.finished;
+        state.bank = obj.bank || 0;
+        state.turnOrder = Array.isArray(obj.turnOrder) ? obj.turnOrder.slice() : null;
+        return state;
+    }
+
+    /**
+     * Execute one player's turn.
+     * @param {Object} actor current player
+     * @param {Function} [chooseTargetFn]
+     */
+    takeTurn(actor, chooseTargetFn = () => actor) {
+        if (!this.shotgun.magazine.length) {
+            this.phase = Phase.ITEMS;
+            return;
+        }
+        if (actor === this.players[1]) {
+            dealerUseItems(this);
+        } else {
+            useItems(this, actor);
+        }
+        const shell = this.shotgun.magazine.shift();
+        const target = actor; // temporary self-target
+        if (shell.type === ShellType.LIVE) {
+            target.hp = Math.max(0, (target.hp || 0) - 1);
+        }
+        this.nextPlayer();
+        if (!this.shotgun.magazine.length) {
+            this.phase = Phase.ITEMS;
+        }
+    }
+
+    /**
+     * Clear the magazine and update win streaks.
+     * @param {Object} winner winning player
+     */
+    resolveRound(winner) {
+        this.shotgun.magazine = [];
+        if (winner === this.players[0]) {
+            this.streak += 1;
+            if (this.streak >= 3) {
+                this.finished = true;
+            }
+        } else {
+            this.streak = 0;
+            this.bank = 0;
+        }
+    }
+
+    /**
+     * Advance turn order respecting skip flags.
+     * @returns {Object} current player
+     */
+    nextPlayer() {
+        if (!Array.isArray(this.turnOrder) || this.turnOrder.length === 0) {
+            this.turnOrder = this.players.map((_, i) => i);
+        }
+        do {
+            this.turnOrder.push(this.turnOrder.shift());
+            this.turn = this.turnOrder[0];
+            const player = this.players[this.turn];
+            if (player && player.flags && player.flags.skip) {
+                player.flags.skip = false;
+            } else {
+                break;
+            }
+        } while (true);
+        return this.players[this.turn];
+    }
+}
+
+/**
+ * Choose round health for all players.
+ * @param {GameState} state game state
+ * @param {Function} [rng=Math.random] random generator
+ * @returns {number} chosen hpMax
+ */
+function setRoundHp(state, rng = Math.random) {
+    const hpMax = 2 + Math.floor(rng() * 3); // 2-4 inclusive
+    if (Array.isArray(state.players)) {
+        state.players.forEach(p => {
+            if (p) {
+                p.hpMax = hpMax;
+                p.hp = hpMax;
+            }
+        });
+    }
+    return hpMax;
+}
+
+/**
+ * Populate the shotgun magazine for a new round.
+ * @param {GameState} state
+ * @param {Function} [rng=Math.random]
+ * @returns {number} number of shells loaded
+ */
+function loadShotgun(state, rng = Math.random) {
+    const magazine = [];
+    const count = (Math.floor(rng() * 4) + 1) * 2; // even number 2-8
+    magazine.push(new Shell(ShellType.LIVE));
+    magazine.push(new Shell(ShellType.BLANK));
+    for (let i = 2; i < count; i++) {
+        magazine.push(new Shell(rng() < 0.5 ? ShellType.LIVE : ShellType.BLANK));
+    }
+    for (let i = magazine.length - 1; i > 0; i--) {
+        const j = Math.floor(rng() * (i + 1));
+        [magazine[i], magazine[j]] = [magazine[j], magazine[i]];
+    }
+    state.shotgun.magazine = magazine;
+    return magazine.length;
+}
+
+/** Base class for all items. */
+class Item {
+    /**
+     * Apply item effect.
+     * @param {GameState} state
+     * @param {Object} owner
+     */
+    apply(state, owner) {}
+}
+
+/** Healing item restoring one HP. */
+class CigarettePack extends Item {
+    apply(state, owner) {
+        if (owner.hp != null && owner.hp < owner.hpMax) {
+            owner.hp++;
+        }
+    }
+}
+
+/** Reveals the first shell type to the owner. */
+class MagnifyingGlass extends Item {
+    apply(state, owner) {
+        owner.lastRevealed = state.shotgun.magazine[0]
+            ? state.shotgun.magazine[0].type
+            : null;
+    }
+}
+
+/** Heals one HP. */
+class Beer extends Item {
+    apply(state, owner) {
+        if (owner.hp != null && owner.hp < owner.hpMax) {
+            owner.hp++;
+        }
+    }
+}
+
+/** Prevents the target's next action. */
+class Handcuffs extends Item {
+    apply(state, owner) {
+        owner.cuffed = true;
+    }
+}
+
+/** Releases from cuffs at the cost of one HP. */
+class Handsaw extends Item {
+    apply(state, owner) {
+        if (owner.cuffed) {
+            owner.cuffed = false;
+            owner.hp = Math.max(0, (owner.hp || 0) - 1);
+        }
+    }
+}
+
+/**
+ * Apply all items owned by the player.
+ * @param {GameState} state
+ * @param {Object} owner
+ */
+function useItems(state, owner) {
+    if (owner.items && owner.items.length) {
+        owner.items.forEach(it => it.apply(state, owner));
+        owner.items = [];
+    }
+}
+
+/**
+ * Steals a random item from the opponent and immediately uses it.
+ */
+class Adrenaline extends Item {
+    apply(state, owner) {
+        owner.adrenaline = true;
+        const opponent = state.players.find(p => p !== owner && p.items && p.items.length);
+        if (opponent) {
+            const rngFn = typeof state.rng === 'function' ? state.rng : Math.random;
+            const idx = Math.floor(rngFn() * opponent.items.length);
+            const [stolen] = opponent.items.splice(idx, 1);
+            owner.items = owner.items || [];
+            owner.items.push(stolen);
+            if (stolen.apply) {
+                stolen.apply(state, owner);
+            }
+        }
+    }
+}
+
+/** Reveals the last shell in the magazine. */
+class Burner extends Item {
+    apply(state, owner) {
+        owner.burnerUsed = true;
+        const idx = state.shotgun.magazine.length - 1;
+        if (idx >= 0) {
+            owner.peeked = state.shotgun.magazine[idx].type;
+        }
+    }
+}
+
+/** Flips the type of the next shell. */
+class Inverter extends Item {
+    apply(state, owner) {
+        owner.inverted = !owner.inverted;
+        if (state.shotgun.magazine.length) {
+            const shell = state.shotgun.magazine[0];
+            shell.type = shell.type === ShellType.LIVE ? ShellType.BLANK : ShellType.LIVE;
+        }
+    }
+}
+
+/** Randomly heal 2 HP or take 1 damage. */
+class ExpiredMedicine extends Item {
+    apply(state, owner) {
+        const rngFn = typeof state.rng === 'function' ? state.rng : Math.random;
+        if (rngFn() < 0.5) {
+            if (owner.hp != null) {
+                owner.hp = Math.min(owner.hpMax, (owner.hp || 0) + 2);
+            }
+            owner.medSuccess = true;
+        } else {
+            if (owner.hp != null) {
+                owner.hp = Math.max(0, (owner.hp || 0) - 1);
+            }
+            owner.medSuccess = false;
+        }
+    }
+}
+
+/** Reverses the current turn order. */
+class Remote extends Item {
+    apply(state, owner) {
+        if (!Array.isArray(state.turnOrder) || state.turnOrder.length === 0) {
+            state.turnOrder = state.players.map((_, i) => i);
+        }
+        const current = state.turnOrder[0];
+        const rest = state.turnOrder.slice(1).reverse();
+        state.turnOrder = [current, ...rest];
+    }
+}
+
+/** Skips the target player's next turn. */
+class Jammer extends Item {
+    constructor(targetIndex = 0) {
+        super();
+        this.targetIndex = targetIndex;
+    }
+    apply(state, owner) {
+        const target = state.players[this.targetIndex];
+        if (target) {
+            target.flags = target.flags || {};
+            target.flags.skip = true;
+        }
+    }
+}
+
+/**
+ * Apply the Double or Nothing decision after a win.
+ * @param {GameState} state
+ * @param {Function} [decisionFn]
+ * @returns {boolean} true if player cashed out
+ */
+function doubleOrNothing(state, decisionFn = () => false) {
+    const continuePlay = decisionFn();
+    if (!continuePlay) {
+        state.bank += Math.pow(2, state.streak);
+        state.streak = 0;
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Execute dealer AI item usage.
+ * @param {GameState} state
+ */
+function dealerUseItems(state) {
+    const dealer = state.players[1];
+    if (!dealer || !dealer.items || !dealer.items.length) return;
+    const priority = [
+        Handcuffs,
+        Adrenaline,
+        MagnifyingGlass,
+        Burner,
+        Inverter,
+        Beer,
+        Handsaw
+    ];
+    for (const Type of priority) {
+        const idx = dealer.items.findIndex(it => it instanceof Type);
+        if (idx !== -1) {
+            const [item] = dealer.items.splice(idx, 1);
+            item.apply(state, dealer);
+            break;
+        }
+    }
+}
+
+/**
+ * Dealer targeting logic based on first shell.
+ * @param {GameState} state
+ * @returns {Object}
+ */
+function dealerChooseTarget(state) {
+    const first = state.shotgun.magazine[0];
+    if (first && first.type === ShellType.LIVE) {
+        return state.players[0];
+    }
+    return state.players[1];
+}
+
+if (typeof module !== 'undefined') {
+    const fs = require('fs');
+    /**
+     * Save game state to a file.
+     * @param {GameState} state
+     * @param {string} file
+     */
+    function saveState(state, file) {
+        fs.writeFileSync(file, JSON.stringify(state.toJSON()), 'utf8');
+    }
+    /**
+     * Load game state from a file.
+     * @param {string} file
+     * @returns {GameState}
+     */
+    function loadState(file) {
+        const data = fs.readFileSync(file, 'utf8');
+        return GameState.fromJSON(data);
+    }
+    module.exports = {
+        ShellType,
+        Shell,
+        Shotgun,
+        Phase,
+        GameState,
+        setRoundHp,
+        loadShotgun,
+        Item,
+        CigarettePack,
+        MagnifyingGlass,
+        Beer,
+        Handcuffs,
+        Handsaw,
+        Adrenaline,
+        Burner,
+        Inverter,
+        ExpiredMedicine,
+        Remote,
+        Jammer,
+        saveState,
+        loadState,
+        dealerChooseTarget,
+        dealerUseItems,
+        useItems,
+        doubleOrNothing,
+        nextPlayer: GameState.prototype.nextPlayer
+    };
+} else {
+    window.ShellType = ShellType;
+    window.Shell = Shell;
+    window.Shotgun = Shotgun;
+    window.Phase = Phase;
+    window.GameState = GameState;
+    window.setRoundHp = setRoundHp;
+    window.loadShotgun = loadShotgun;
+    window.Item = Item;
+    window.CigarettePack = CigarettePack;
+    window.MagnifyingGlass = MagnifyingGlass;
+    window.Beer = Beer;
+    window.Handcuffs = Handcuffs;
+    window.Handsaw = Handsaw;
+    window.Adrenaline = Adrenaline;
+    window.Burner = Burner;
+    window.Inverter = Inverter;
+    window.ExpiredMedicine = ExpiredMedicine;
+    window.Remote = Remote;
+    window.Jammer = Jammer;
+    window.saveState = function(state, file) {
+        console.warn('saveState is Node-only');
+    };
+    window.loadState = function(file) {
+        console.warn('loadState is Node-only');
+    };
+    window.dealerChooseTarget = dealerChooseTarget;
+    window.dealerUseItems = dealerUseItems;
+    window.useItems = useItems;
+    window.doubleOrNothing = doubleOrNothing;
+    window.nextPlayer = GameState.prototype.nextPlayer;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "galacticreserve",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node tests/test_step1.js && node tests/test_step2.js && node tests/test_step5.js && node tests/test_step6.js && node tests/test_step7.js && node tests/test_step8.js && node tests/test_step9.js && node tests/test_step10.js && node tests/test_step11.js && node tests/test_step12.js && node tests/test_step13.js && node tests/test_step14.js && node tests/test_step15.js && node tests/test_step16.js && node tests/test_step19.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Buckshot Roulette</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/buckshot.css">
+    <script src="../js/buckshot.js" defer></script>
+</head>
+<body>
+    <div class="nav-bar">
+        <div class="logo-container">
+            <div class="logo"></div>
+        </div>
+        <div class="bank-name" onclick="location.href='../index.html'">Galactic Reserve</div>
+        <div class="nav-item" onclick="location.href='../index.html'">Back to the Strategies</div>
+    </div>
+    <div class="buckshot-container">
+        <h1>Buckshot Roulette</h1>
+        <div id="gameArea" class="game-area">
+            <!-- Game interface will be implemented here -->
+        </div>
+        <div class="controls">
+            <button class="baton" id="newGame">New Game</button>
+        </div>
+        <div id="status" class="status"></div>
+    </div>
+</body>
+</html>

--- a/tests/test_step1.js
+++ b/tests/test_step1.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const { Shell, ShellType } = require('../js/buckshotCore');
+
+for (let i = 0; i < 10; i++) {
+  const type = i % 2 === 0 ? ShellType.LIVE : ShellType.BLANK;
+  const shell = new Shell(type);
+  assert.strictEqual(shell.type, type);
+}
+console.log('Step 1: Shell type test passed');

--- a/tests/test_step10.js
+++ b/tests/test_step10.js
@@ -1,0 +1,42 @@
+const assert = require('assert');
+const { GameState, Shotgun, Shell, ShellType,
+  Handcuffs, Adrenaline, MagnifyingGlass, Burner, Inverter, Beer, Handsaw,
+  dealerUseItems } = require('../js/buckshotCore');
+
+const state = new GameState({ players: [{hp:1,hpMax:2}, {hp:1,hpMax:2, items:[]}], shotgun: new Shotgun() });
+const dealer = state.players[1];
+
+// Handcuffs over Beer
+dealer.items = [new Beer(), new Handcuffs()];
+dealerUseItems(state);
+assert.ok(dealer.cuffed);
+assert.strictEqual(dealer.items.length, 1);
+assert.ok(dealer.items[0] instanceof Beer);
+
+dealer.cuffed = false;
+// Adrenaline over Inverter
+dealer.items = [new Inverter(), new Adrenaline()];
+dealerUseItems(state);
+assert.ok(dealer.adrenaline);
+assert.strictEqual(dealer.items.length, 1);
+assert.ok(dealer.items[0] instanceof Inverter);
+
+// Magnify over Beer and Handsaw
+state.shotgun.magazine = [new Shell(ShellType.LIVE)];
+dealer.adrenaline = false;
+dealer.items = [new Handsaw(), new MagnifyingGlass(), new Beer()];
+dealerUseItems(state);
+assert.strictEqual(dealer.lastRevealed, ShellType.LIVE);
+assert.strictEqual(dealer.items.length, 2);
+assert.ok(dealer.items.some(it => it instanceof Handsaw));
+assert.ok(dealer.items.some(it => it instanceof Beer));
+
+// Beer over Handsaw
+dealer.hp = 1;
+dealer.items = [new Handsaw(), new Beer()];
+dealerUseItems(state);
+assert.strictEqual(dealer.hp, 2);
+assert.strictEqual(dealer.items.length, 1);
+assert.ok(dealer.items[0] instanceof Handsaw);
+
+console.log('Step 10: dealer item priority test passed');

--- a/tests/test_step11.js
+++ b/tests/test_step11.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const { GameState, Shotgun, Shell, ShellType } = require('../js/buckshotCore');
+
+const state = new GameState({ players: [{}, {}], shotgun: new Shotgun() });
+state.shotgun.magazine = [new Shell(ShellType.LIVE)];
+
+state.resolveRound(state.players[0]);
+assert.strictEqual(state.streak, 1);
+assert.strictEqual(state.shotgun.magazine.length, 0);
+assert.strictEqual(state.finished, false);
+
+state.resolveRound(state.players[0]);
+state.resolveRound(state.players[0]);
+assert.strictEqual(state.finished, true);
+console.log('Step 11: resolveRound test passed');

--- a/tests/test_step12.js
+++ b/tests/test_step12.js
@@ -1,0 +1,21 @@
+const assert = require('assert');
+const { GameState, Shotgun, doubleOrNothing } = require('../js/buckshotCore');
+
+const state = new GameState({ players: [{}, {}], shotgun: new Shotgun() });
+
+// first win, choose to continue
+state.resolveRound(state.players[0]);
+doubleOrNothing(state, () => true);
+assert.strictEqual(state.bank, 0);
+assert.strictEqual(state.streak, 1);
+
+// second win, take money
+state.resolveRound(state.players[0]);
+doubleOrNothing(state, () => false);
+assert.strictEqual(state.bank, 4);
+assert.strictEqual(state.streak, 0);
+
+// losing resets bank
+state.resolveRound(state.players[1]);
+assert.strictEqual(state.bank, 0);
+console.log('Step 12: double or nothing test passed');

--- a/tests/test_step13.js
+++ b/tests/test_step13.js
@@ -1,0 +1,33 @@
+const assert = require('assert');
+const { GameState, Shotgun, Shell, ShellType,
+  Adrenaline, Burner, Inverter, ExpiredMedicine } = require('../js/buckshotCore');
+
+// Adrenaline steals item and applies it
+let state = new GameState({ players: [{hp:1,hpMax:2, items:[new Adrenaline()]}, {items:[new Burner()], hp:1,hpMax:2}] });
+const player = state.players[0];
+const opponent = state.players[1];
+player.items[0].apply(state, player);
+assert.strictEqual(opponent.items.length, 0);
+assert.strictEqual(player.items.length, 2);
+assert.ok(player.burnerUsed);
+
+// Inverter flips current shell
+state = new GameState({ players:[{}], shotgun:new Shotgun() });
+state.shotgun.magazine = [new Shell(ShellType.LIVE)];
+new Inverter().apply(state, state.players[0]);
+assert.strictEqual(state.shotgun.magazine[0].type, ShellType.BLANK);
+
+// Burner reveals last shell
+state = new GameState({ players:[{}], shotgun:new Shotgun() });
+state.shotgun.magazine = [new Shell(ShellType.BLANK), new Shell(ShellType.LIVE)];
+new Burner().apply(state, state.players[0]);
+assert.strictEqual(state.players[0].peeked, ShellType.LIVE);
+
+// Expired medicine random effect
+let rngVals = [0.3, 0.7];
+state = new GameState({ players:[{hp:1,hpMax:3}], rng: () => rngVals.shift() });
+new ExpiredMedicine().apply(state, state.players[0]);
+assert.strictEqual(state.players[0].hp, 3);
+new ExpiredMedicine().apply(state, state.players[0]);
+assert.strictEqual(state.players[0].hp, 2);
+console.log('Step 13: DoN items test passed');

--- a/tests/test_step14.js
+++ b/tests/test_step14.js
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const { GameState, Shotgun, Shell, ShellType, Phase, nextPlayer } = require('../js/buckshotCore');
+
+const state = new GameState({
+  phase: Phase.MAIN,
+  players: [{hp:1},{hp:1},{hp:1}],
+  shotgun: new Shotgun(),
+  turnOrder: [0,1,2]
+});
+state.shotgun.magazine = [new Shell(ShellType.BLANK), new Shell(ShellType.BLANK)];
+state.takeTurn(state.players[state.turn]);
+assert.strictEqual(state.turn, 1);
+state.takeTurn(state.players[state.turn]);
+assert.strictEqual(state.turn, 2);
+state.nextPlayer();
+assert.strictEqual(state.turn, 0);
+console.log('Step 14: multiplayer turn order test passed');

--- a/tests/test_step15.js
+++ b/tests/test_step15.js
@@ -1,0 +1,28 @@
+const assert = require('assert');
+const { GameState, Shotgun, Phase, Remote, Jammer } = require('../js/buckshotCore');
+
+// Remote reverses turn order
+let state = new GameState({
+  phase: Phase.MAIN,
+  players: [{},{},{},{}],
+  shotgun: new Shotgun(),
+  turnOrder: [0,1,2,3]
+});
+new Remote().apply(state, state.players[0]);
+assert.deepStrictEqual(state.turnOrder, [0,3,2,1]);
+state.nextPlayer();
+assert.strictEqual(state.turn, 3);
+
+// Jammer skips targeted player once
+state = new GameState({
+  phase: Phase.MAIN,
+  players: [{flags:{}},{flags:{}},{flags:{}},{flags:{}}],
+  shotgun: new Shotgun(),
+  turnOrder: [0,1,2,3]
+});
+new Jammer(2).apply(state, state.players[0]);
+state.nextPlayer(); // to player 1
+state.nextPlayer(); // should skip player 2
+assert.strictEqual(state.turn, 3);
+
+console.log('Step 15: Remote and Jammer test passed');

--- a/tests/test_step16.js
+++ b/tests/test_step16.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const fs = require('fs');
+const { GameState, Shotgun, saveState, loadState } = require('../js/buckshotCore');
+
+const file = 'tests/tmp_state.json';
+const state = new GameState({ players:[{hp:2,hpMax:2}], shotgun:new Shotgun() });
+state.players[0].hp = 1;
+saveState(state, file);
+const loaded = loadState(file);
+assert.strictEqual(JSON.stringify(loaded.toJSON()), JSON.stringify(state.toJSON()));
+fs.unlinkSync(file);
+console.log('Step 16: save/load CLI test passed');

--- a/tests/test_step19.js
+++ b/tests/test_step19.js
@@ -1,0 +1,39 @@
+const assert = require('assert');
+const { GameState, Shotgun, setRoundHp, loadShotgun } = require('../js/buckshotCore');
+
+function startRound(state) {
+  setRoundHp(state);
+  loadShotgun(state);
+  state.turnOrder = [0,1];
+  state.turn = 0;
+}
+
+function roundWinner(state) {
+  const p1 = state.players[0];
+  const p2 = state.players[1];
+  if (p1.hp <= 0 && p2.hp <= 0) return null;
+  if (p1.hp <= 0) return p2;
+  if (p2.hp <= 0) return p1;
+  if (!state.shotgun.magazine.length) return p1.hp >= p2.hp ? p1 : p2;
+  return null;
+}
+
+function playGame() {
+  const state = new GameState({ players: [{}, {}], shotgun: new Shotgun() });
+  startRound(state);
+  while (true) {
+    const actor = state.players[state.turn];
+    state.takeTurn(actor);
+    const winner = roundWinner(state);
+    if (winner) return winner === state.players[0] ? 0 : 1;
+  }
+}
+
+let wins = [0, 0];
+for (let i = 0; i < 10000; i++) {
+  wins[playGame()]++;
+}
+
+const ratio = wins[0] / (wins[0] + wins[1]);
+assert(ratio > 0.3 && ratio < 0.7);
+console.log('Step 19: stress test passed');

--- a/tests/test_step2.js
+++ b/tests/test_step2.js
@@ -1,0 +1,23 @@
+const assert = require('assert');
+const { GameState, Shotgun, Shell, ShellType, Phase } = require('../js/buckshotCore');
+
+// Build initial state
+const shotgun = new Shotgun();
+shotgun.magazine.push(new Shell(ShellType.LIVE));
+shotgun.magazine.push(new Shell(ShellType.BLANK));
+const state = new GameState({
+  phase: Phase.LOAD,
+  round: 2,
+  turn: 1,
+  players: ['Alice', 'Bob'],
+  shotgun,
+  rng: 42,
+  streak: 3,
+  finished: false
+});
+
+const json = JSON.stringify(state.toJSON());
+const restored = GameState.fromJSON(JSON.parse(json));
+
+assert.deepStrictEqual(restored, state);
+console.log('Step 2: GameState serialization test passed');

--- a/tests/test_step5.js
+++ b/tests/test_step5.js
@@ -1,0 +1,11 @@
+const assert = require('assert');
+const { GameState, setRoundHp } = require('../js/buckshotCore');
+
+const rng = () => 0.8; // deterministic -> hpMax = 4
+const state = new GameState({ players: [{}, {}] });
+const hpMax = setRoundHp(state, rng);
+assert.strictEqual(hpMax, state.players[0].hp);
+assert.strictEqual(hpMax, state.players[0].hpMax);
+assert.strictEqual(hpMax, state.players[1].hp);
+assert.strictEqual(hpMax, state.players[1].hpMax);
+console.log('Step 5: setRoundHp test passed');

--- a/tests/test_step6.js
+++ b/tests/test_step6.js
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const { GameState, Shotgun, loadShotgun, ShellType } = require('../js/buckshotCore');
+
+let nums = [0.3, 0.7, 0.2, 0.9, 0.1, 0.4, 0.8];
+let idx = 0;
+const rng = () => nums[idx++ % nums.length];
+
+const state = new GameState({ shotgun: new Shotgun(), players: [] });
+loadShotgun(state, rng);
+const mag = state.shotgun.magazine;
+assert.ok(mag.length >= 2 && mag.length <= 8 && mag.length % 2 === 0);
+const hasLive = mag.some(s => s.type === ShellType.LIVE);
+const hasBlank = mag.some(s => s.type === ShellType.BLANK);
+assert.ok(hasLive && hasBlank);
+console.log('Step 6: loadShotgun test passed');

--- a/tests/test_step7.js
+++ b/tests/test_step7.js
@@ -1,0 +1,20 @@
+const assert = require('assert');
+const { GameState, Shotgun, Shell, ShellType, Phase } = require('../js/buckshotCore');
+
+const state = new GameState({
+  phase: Phase.MAIN,
+  players: [{hp:1,hpMax:1}, {hp:1,hpMax:1}],
+  shotgun: new Shotgun()
+});
+state.shotgun.magazine = [new Shell(ShellType.BLANK), new Shell(ShellType.BLANK)];
+
+state.takeTurn(state.players[state.turn]);
+assert.strictEqual(state.turn, 1);
+assert.strictEqual(state.shotgun.magazine.length, 1);
+assert.strictEqual(state.phase, Phase.MAIN);
+
+state.takeTurn(state.players[state.turn]);
+assert.strictEqual(state.turn, 0);
+assert.strictEqual(state.shotgun.magazine.length, 0);
+assert.strictEqual(state.phase, Phase.ITEMS);
+console.log('Step 7: takeTurn basic test passed');

--- a/tests/test_step8.js
+++ b/tests/test_step8.js
@@ -1,0 +1,32 @@
+const assert = require('assert');
+const { GameState, Shotgun, Shell, ShellType,
+  CigarettePack, MagnifyingGlass, Beer, Handcuffs, Handsaw, useItems } = require('../js/buckshotCore');
+
+const state = new GameState({ shotgun: new Shotgun() });
+state.shotgun.magazine = [new Shell(ShellType.LIVE)];
+const player = { hp:1, hpMax:2, items: [] };
+
+player.items = [new CigarettePack()];
+useItems(state, player);
+assert.strictEqual(player.hp, 2);
+
+player.items = [new MagnifyingGlass()];
+useItems(state, player);
+assert.strictEqual(player.lastRevealed, ShellType.LIVE);
+
+player.hp = 1;
+player.hpMax = 3;
+player.items = [new Beer()];
+useItems(state, player);
+assert.strictEqual(player.hp, 2);
+
+player.items = [new Handcuffs()];
+useItems(state, player);
+assert.ok(player.cuffed);
+
+player.items = [new Handsaw()];
+useItems(state, player);
+assert.ok(!player.cuffed);
+assert.strictEqual(player.hp, 1);
+
+console.log('Step 8: item effects test passed');

--- a/tests/test_step9.js
+++ b/tests/test_step9.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { GameState, Shotgun, Shell, ShellType, dealerChooseTarget } = require('../js/buckshotCore');
+
+let state = new GameState({ players: [{name:'P'}, {name:'D'}], shotgun: new Shotgun() });
+state.shotgun.magazine = [new Shell(ShellType.LIVE)];
+let target = dealerChooseTarget(state);
+assert.strictEqual(target, state.players[0]);
+
+state = new GameState({ players: [{name:'P'}, {name:'D'}], shotgun: new Shotgun() });
+state.shotgun.magazine = [new Shell(ShellType.BLANK)];
+target = dealerChooseTarget(state);
+assert.strictEqual(target, state.players[1]);
+
+console.log('Step 9: dealerChooseTarget test passed');


### PR DESCRIPTION
## Summary
- implement a minimal Node CLI for Buckshot Roulette
- document public API via JSDoc comments
- add README with usage instructions and a Mermaid state diagram
- add stress test simulating 10k random games

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684867949bec8323bd4041a41ceb173d