### PR TITLE
Enhance Buckshot Roulette layout

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -1,0 +1,153 @@
+/* Buckshot Roulette game layout */
+.game-board {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-rows: 40px 1fr 110px;
+    grid-template-areas:
+        "turn turn turn"
+        "player stage dealer"
+        "items items items";
+    gap: 10px;
+    height: calc(100vh - 60px);
+    position: relative;
+}
+.turn-indicator {
+    grid-area: turn;
+    background: #21262d;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    position: sticky;
+    top: 0;
+    z-index: 10;
+}
+.hud {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 10px;
+}
+.charge-bar {
+    display: flex;
+    gap: 4px;
+    margin: 6px 0;
+}
+.charge-bar .charge::before {
+    content: "\2764";
+    color: #ff5555;
+    font-size: 18px;
+}
+.stage {
+    grid-area: stage;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    position: relative;
+}
+.shotgun {
+    width: 220px;
+    height: 60px;
+    background: linear-gradient(#555, #222);
+    border-radius: 8px;
+    transition: transform 0.2s;
+}
+.shotgun:hover { transform: rotate(-3deg); }
+.shotgun.kick { animation: kick 0.2s; }
+@keyframes kick {
+    0% { transform: translateX(0); }
+    50% { transform: translateX(-10px); }
+    100% { transform: translateX(0); }
+}
+.magazine {
+    display: flex;
+    margin-top: 10px;
+}
+.shell {
+    width: 20px;
+    height: 30px;
+    margin: 0 2px;
+    background: #333;
+    border: 1px solid #999;
+    border-radius: 3px;
+}
+.shell.live.revealed { background: #c33; }
+.shell.blank.revealed { background: #3c3; }
+.splashes {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    pointer-events: none;
+}
+.splash {
+    position: absolute;
+    animation: splash 1s forwards;
+    color: #fff;
+    font-weight: bold;
+}
+@keyframes splash {
+    0% { opacity: 1; transform: translateY(0); }
+    100% { opacity: 0; transform: translateY(-40px); }
+}
+.item-tray {
+    grid-area: items;
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    padding: 10px;
+    border-top: 1px solid #30363d;
+    min-height: 110px;
+}
+.item {
+    width: 88px;
+    height: 88px;
+    background: #21262d;
+    border: 1px solid #555;
+    border-radius: 6px;
+    position: relative;
+}
+.action-bar {
+    position: absolute;
+    bottom: calc(110px + 8px);
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+}
+.game-btn {
+    padding: 10px 16px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-family: 'Orbitron', sans-serif;
+    transition: transform 0.1s;
+}
+.game-btn:active { transform: scale(0.95); }
+.game-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.game-btn.shoot-enemy { background: #e67e22; color: #fff; }
+.game-btn.pass { background: #777; color: #fff; }
+.game-btn { background: #d33; color: #fff; }
+.status { margin-top: 10px; height: 24px; }
+
+@media (max-width: 960px) {
+    .game-board {
+        grid-template-columns: 1fr;
+        grid-template-rows: 40px auto auto auto 110px;
+        grid-template-areas:
+            "turn"
+            "stage"
+            "dealer"
+            "player"
+            "items";
+    }
+    .action-bar {
+        position: fixed;
+        bottom: 0;
+        background: #21262d;
+        padding: 8px 0;
+    }
+    .item { width: 64px; height: 64px; }
+}

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
                 <button class="baton" onclick="location.href='pages/tactic21.html'">Tactic-21</button>
                 <button class="baton" onclick="location.href='pages/durak.html'">Durak</button>
                 <button class="baton" onclick="location.href='pages/uno.html'">UNO</button>
+                <button class="baton" onclick="location.href='pages/buckshot.html'">Buckshot Roulette</button>
             </div>
         </div>
     </div>

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -1,0 +1,158 @@
+let playerCharges = 3;
+let dealerCharges = 3;
+let magazine = [];
+let turn = 'player';
+let position = 0;
+
+function updateCharges(el, count) {
+    el.innerHTML = '';
+    for (let i = 0; i < count; i++) {
+        const c = document.createElement('span');
+        c.className = 'charge';
+        el.appendChild(c);
+    }
+}
+
+function showSplash(text) {
+    const splash = document.createElement('div');
+    splash.className = 'splash';
+    splash.textContent = text;
+    document.getElementById('splashes').appendChild(splash);
+    setTimeout(() => splash.remove(), 1000);
+}
+
+function setupGame() {
+    playerCharges = 3;
+    dealerCharges = 3;
+    magazine = [];
+    const total = 6;
+    const liveCount = 2;
+    for (let i = 0; i < total; i++) {
+        magazine.push(i < liveCount);
+    }
+    // shuffle magazine
+    for (let i = magazine.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [magazine[i], magazine[j]] = [magazine[j], magazine[i]];
+    }
+    position = 0;
+    turn = 'player';
+    updateDisplay('Game start!');
+    refreshControls();
+}
+
+function updateDisplay(msg) {
+    updateCharges(document.getElementById('playerCharges'), playerCharges);
+    updateCharges(document.getElementById('dealerCharges'), dealerCharges);
+    document.getElementById('status').textContent = msg;
+    const magEl = document.getElementById('magazine');
+    magEl.innerHTML = '';
+    for (let i = position; i < magazine.length; i++) {
+        const shell = document.createElement('div');
+        shell.className = 'shell';
+        shell.dataset.index = i;
+        magEl.appendChild(shell);
+    }
+}
+
+function resolveShot(target) {
+    if (position >= magazine.length) {
+        updateDisplay('No shells left.');
+        return endRound();
+    }
+    const isLive = magazine[position];
+    position++;
+    const shellEl = document.querySelector(`#magazine .shell`);
+    if (shellEl) {
+        shellEl.classList.add(isLive ? 'live' : 'blank', 'revealed');
+    }
+    document.getElementById('shotgun').classList.add('kick');
+    setTimeout(() => document.getElementById('shotgun').classList.remove('kick'), 200);
+    if (isLive) {
+        if (target === 'player') playerCharges--; else dealerCharges--;
+        showSplash('-1 HP');
+        updateDisplay(`${target === 'player' ? 'Player' : 'Dealer'} shot!`);
+        turn = turn === 'player' ? 'dealer' : 'player';
+    } else {
+        showSplash('Blank');
+        updateDisplay('Click again, it was blank.');
+    }
+    checkGameOver();
+}
+
+function checkGameOver() {
+    if (playerCharges <= 0 || dealerCharges <= 0) {
+        endRound();
+    }
+}
+
+function refreshControls() {
+    const playerTurn = turn === 'player';
+    document.getElementById('shootSelf').disabled = !playerTurn;
+    document.getElementById('shootDealer').disabled = !playerTurn;
+    document.getElementById('passBtn').disabled = !playerTurn;
+    document.getElementById('turnIndicator').textContent = playerTurn ? 'Your Turn' : "Dealer's Turn";
+}
+
+function shootSelf() {
+    if (turn !== 'player') return;
+    resolveShot('player');
+    refreshControls();
+    if (turn === 'dealer') dealerTurn();
+}
+
+function shootDealer() {
+    if (turn !== 'player') return;
+    resolveShot('dealer');
+    refreshControls();
+    if (turn === 'dealer') dealerTurn();
+}
+
+function passTurn() {
+    if (turn !== 'player') return;
+    turn = 'dealer';
+    updateDisplay('Player passed.');
+    refreshControls();
+    dealerTurn();
+}
+
+function dealerTurn() {
+    if (position >= magazine.length) return endRound();
+    if (dealerCharges <= 0 || playerCharges <= 0) return;
+    refreshControls();
+    setTimeout(() => {
+        const choice = Math.random() < 0.5 ? 'self' : 'player';
+        if (choice === 'self') {
+            resolveShot('dealer');
+        } else {
+            resolveShot('player');
+        }
+        refreshControls();
+        if (turn === 'dealer') dealerTurn();
+    }, 800);
+}
+
+function endRound() {
+    let msg = 'Round over. ';
+    if (playerCharges <= 0 && dealerCharges <= 0) msg += 'Draw!';
+    else if (playerCharges <= 0) msg += 'Dealer wins!';
+    else if (dealerCharges <= 0) msg += 'Player wins!';
+    else msg += 'No more shells.';
+    updateDisplay(msg);
+    document.getElementById('shootSelf').disabled = true;
+    document.getElementById('shootDealer').disabled = true;
+    document.getElementById('passBtn').disabled = true;
+    document.getElementById('turnIndicator').textContent = 'Round Over';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    document.getElementById('shootSelf').addEventListener('click', shootSelf);
+    document.getElementById('shootDealer').addEventListener('click', shootDealer);
+    document.getElementById('passBtn').addEventListener('click', passTurn);
+    document.addEventListener('keydown', (e) => {
+        if (e.code === 'Space') shootSelf();
+        if (e.code === 'KeyE') shootDealer();
+        if (e.code === 'Enter') passTurn();
+    });
+    setupGame();
+});

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Buckshot Roulette</title>
+    <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="../css/style.css">
+    <link rel="stylesheet" href="../css/buckshot.css">
+    <script src="../js/buckshot.js" defer></script>
+</head>
+<body>
+    <div class="nav-bar">
+        <div class="logo-container">
+            <div class="logo"></div>
+        </div>
+        <div class="bank-name" onclick="location.href='../index.html'">Galactic Reserve</div>
+        <div class="nav-item" onclick="location.href='../index.html'">Back to the Strategies</div>
+    </div>
+    <div class="game-board">
+        <div id="turnIndicator" class="turn-indicator">Your Turn</div>
+        <div class="hud player-hud">
+            <h2>Player</h2>
+            <div id="playerCharges" class="charge-bar"></div>
+            <div class="cash">$<span id="playerCash">0</span></div>
+            <div id="playerBuffs" class="buffs"></div>
+        </div>
+        <div class="stage">
+            <div id="shotgun" class="shotgun"></div>
+            <div id="splashes" class="splashes"></div>
+            <div id="status" class="status"></div>
+            <div id="magazine" class="magazine"></div>
+        </div>
+        <div class="hud dealer-hud">
+            <h2>Dealer</h2>
+            <div id="dealerCharges" class="charge-bar"></div>
+            <div class="cash">$<span id="dealerCash">0</span></div>
+            <div id="dealerBuffs" class="buffs"></div>
+        </div>
+        <div id="itemTray" class="item-tray"></div>
+        <div class="action-bar">
+            <button class="game-btn" id="shootSelf">ВЫСТРЕЛИТЬ СЕБЕ</button>
+            <button class="game-btn shoot-enemy" id="shootDealer">СТРЕЛЯТЬ В Dealer</button>
+            <button class="game-btn pass" id="passBtn">ПЕРЕДАТЬ</button>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- redesign Buckshot Roulette page using grid layout
- add turn indicator, HUD panels, shotgun stage and action bar
- style magazine, shell animations and buttons
- improve JS with controls refresh and keyboard shortcuts

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848bb9899588323a4873526b8b55f00