### PR TITLE
Add HP bars and adjustable animation

### DIFF
--- a/BuckshotRoulettePlan.md
+++ b/BuckshotRoulettePlan.md
@@ -11,7 +11,7 @@ Each round goes through several phases:
 | Phase | Description | Browser Considerations |
 |-------|-------------|------------------------|
 | **Item phase** | Each participant receives 2–5 random items (max 8 slots). | Inventory UI with drag&drop or "use" button. *(partially)* |
-| **Health phase** | Overall HP for the round (2–4) is shown via a pulse meter. | Track `maxCharges` and `currentCharges` for all players. *(partially - HP randomised)* |
+| **Health phase** | Overall HP for the round (2–4) is shown via a pulse meter. | Track `maxCharges` and `currentCharges` for all players. *(fully implemented)* |
 | **Loading phase** | Dealer displays 2–8 shells then shuffles them. If even: half live, half blank. If odd: difference exactly 1. | Function `generateLoad(size)` implements distribution. *(fully)* |
 | **Main phase** | Players take turns. On their turn they may use items, then fire the shotgun at themselves or a target. A blank self-shot keeps the turn, anything else ends it. | Finite-state machine (PlayerTurn → DealerTurn → …) with life checks and automatic reload when magazine empty. *(partially)* |
 
@@ -103,7 +103,7 @@ stateDiagram
 
 ## 7. Additional Features
 - Colorblind filter to distinguish shell types. *(fully implemented)*
-- Adjustable animation speed (0.5×–2×).
+- Adjustable animation speed (0.5×–2×). *(fully implemented)*
 - Option to save RNG seed for replays and debugging. *(fully implemented)*
 - Settings modal to toggle colorblind mode and enter RNG seed. *(fully implemented)*
 - Modding API (original uses Godot mods).

--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -18,6 +18,20 @@
     width: 150px;
     text-align: center;
 }
+.hp-bar {
+    width: 100px;
+    height: 10px;
+    background: #333;
+    border: 1px solid #555;
+    margin: 4px auto;
+    position: relative;
+}
+.hp-fill {
+    background: red;
+    height: 100%;
+    width: 100%;
+    transition: width 0.3s;
+}
 .items {
     margin-top: 10px;
     display: flex;

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -8,6 +8,7 @@ class Player {
     constructor(name) {
         this.name = name;
         this.hp = 3;
+        this.maxHp = 3;
         this.items = [];
         this.damageBoost = 1; // multiplier for next live shot
     }
@@ -23,6 +24,7 @@ class Game {
         this.knownShell = null; // dealer knowledge of next shell
         this.dealerSkip = false; // whether dealer loses next turn
         this.seed = Date.now();
+        this.animationSpeed = 1;
     }
 
     setSeed(seed) {
@@ -40,8 +42,8 @@ class Game {
         const seedInput = document.getElementById('seedInput');
         if(seedInput && seedInput.value) this.setSeed(Number(seedInput.value));
         const hp = 2 + Math.floor(this.random() * 3); // 2-4
-        this.player.hp = hp;
-        this.dealer.hp = hp;
+        this.player.hp = this.player.maxHp = hp;
+        this.dealer.hp = this.dealer.maxHp = hp;
         this.player.damageBoost = 1;
         this.dealer.damageBoost = 1;
         this.player.items = this.randomItems();
@@ -168,11 +170,20 @@ const shootDealer=document.getElementById('shootDealer');
 const settingsBtn=document.getElementById('settingsButton');
 const settingsModal=document.getElementById('settingsModal');
 const colorblindToggle=document.getElementById('colorblindToggle');
+const speedRange=document.getElementById('speedRange');
+const speedDisplay=document.getElementById('speedDisplay');
 
 if(colorblindToggle){
     colorblindToggle.addEventListener('change',()=>{
         document.querySelector('.bs-container').classList.toggle('colorblind', colorblindToggle.checked);
     });
+}
+if(speedRange){
+    speedRange.addEventListener('input',()=>{
+        game.animationSpeed=parseFloat(speedRange.value);
+        if(speedDisplay) speedDisplay.textContent=speedRange.value+'x';
+    });
+    if(speedDisplay) speedDisplay.textContent=speedRange.value+'x';
 }
 
 startBtn.addEventListener('click',()=>game.startRound());
@@ -183,11 +194,11 @@ if(settingsBtn){
 }
 shootSelf.addEventListener('click',()=>{
     game.shoot(game.player, game.player);
-    if(game.player.hp>0 && game.dealer.hp>0) setTimeout(()=>game.dealerTurn(),500);
+    if(game.player.hp>0 && game.dealer.hp>0) setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
 });
 shootDealer.addEventListener('click',()=>{
     game.shoot(game.dealer, game.player);
-    if(game.player.hp>0 && game.dealer.hp>0) setTimeout(()=>game.dealerTurn(),500);
+    if(game.player.hp>0 && game.dealer.hp>0) setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
 });
 
 function updateItems(el,items) {
@@ -264,6 +275,14 @@ function setStatus(text){
 Game.prototype.updateUI=function(){
     document.getElementById('playerHp').textContent=this.player.hp;
     document.getElementById('dealerHp').textContent=this.dealer.hp;
+    const pBar=document.getElementById('playerHpBar');
+    const dBar=document.getElementById('dealerHpBar');
+    if(pBar){
+        pBar.style.width=(100*this.player.hp/this.player.maxHp)+'%';
+    }
+    if(dBar){
+        dBar.style.width=(100*this.dealer.hp/this.dealer.maxHp)+'%';
+    }
     updateItems(document.getElementById('playerItems'),this.player.items);
     updateItems(document.getElementById('dealerItems'),this.dealer.items);
     updateMagazine(document.getElementById('magazine'),this.magazine,this.current);

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -30,11 +30,13 @@
             <div class="player" id="player">
                 <h2>Player</h2>
                 <div>HP: <span id="playerHp">3</span></div>
+                <div class="hp-bar"><div class="hp-fill" id="playerHpBar"></div></div>
                 <div id="playerItems" class="items"></div>
             </div>
             <div class="player" id="dealer">
                 <h2>Dealer</h2>
                 <div>HP: <span id="dealerHp">3</span></div>
+                <div class="hp-bar"><div class="hp-fill" id="dealerHpBar"></div></div>
                 <div id="dealerItems" class="items"></div>
             </div>
         </div>
@@ -47,6 +49,9 @@
             <input id="seedInput" type="number" placeholder="Seed (optional)">
             <br>
             <label><input type="checkbox" id="colorblindToggle"> Colorblind Mode</label>
+            <br>
+            <label>Animation Speed: <span id="speedDisplay">1x</span></label>
+            <input id="speedRange" type="range" min="0.5" max="2" step="0.1" value="1">
         </div>
     </div>
 </body>


### PR DESCRIPTION
## Summary
- add HP progress bars for player and dealer
- implement adjustable animation speed with slider
- track max HP and update pulse meters in UI
- update plan to mark Health phase and animation speed as fully implemented

## Testing
- `echo "No tests"`

------
https://chatgpt.com/codex/tasks/task_e_6848cce3d9a08323ae2ac037502b9b23