### PR TITLE
Rename Settings to Features

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -83,3 +83,11 @@
         white 8px
     );
 }
+
+/* Position the Features button in the bottom-left corner */
+#settingsButton {
+    position: fixed;
+    bottom: 20px;
+    left: 20px;
+    z-index: 1100;
+}

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -21,7 +21,7 @@
         <h1>Buckshot Roulette</h1>
         <div class="status" id="status">Press Start to begin.</div>
         <div class="controls">
-            <button class="baton" id="settingsButton">&#9881; Settings</button>
+            <button class="baton" id="settingsButton">&#9881; Features</button>
             <button class="baton" id="startBtn">Start Round</button>
             <button class="baton" id="shootSelf" disabled>Shoot Self</button>
             <button class="baton" id="shootDealer" disabled>Shoot Dealer</button>
@@ -45,7 +45,7 @@
     <div id="settingsModal" class="modal">
         <div class="modal-content">
             <span class="close" onclick="document.getElementById('settingsModal').style.display='none'">&times;</span>
-            <h2>Settings</h2>
+            <h2>Features</h2>
             <input id="seedInput" type="number" placeholder="Seed (optional)">
             <br>
             <label><input type="checkbox" id="colorblindToggle"> Colorblind Mode</label>


### PR DESCRIPTION
## Summary
- re-label the Settings menu as **Features** in Buckshot Roulette
- pin the Features button to the bottom-left of the screen

## Testing
- `node test.js` *(displays "display: flex" verifying the modal appears)*

------
https://chatgpt.com/codex/tasks/task_e_6848ce89bb248323a1a9fa70aee8258c