### PR TITLE
Add Double or Nothing option

### DIFF
--- a/BuckshotRoulettePlan.md
+++ b/BuckshotRoulettePlan.md
@@ -35,6 +35,7 @@ The round ends when a player’s HP reaches 0 or the magazine is empty. Winning 
 | **Inverter** | Converts current shell: blank ↔ live. *(fully implemented)* |
 | **Expired Medicine** | 50% chance +2 HP, 50% chance −1 HP. *(fully implemented)* |
 These items appear only in Double or Nothing mode.
+Double or Nothing is enabled by default so these items normally appear.
 
 ### 3.3 Multiplayer only
 | Item | Effect |
@@ -107,7 +108,7 @@ stateDiagram
 - Adjustable animation speed (0.5×–2×). *(fully implemented)*
 - Option to save RNG seed for replays and debugging. *(fully implemented)*
 - Settings modal to toggle colorblind mode and enter RNG seed. *(fully implemented)*
-- Toggle for Double or Nothing mode enabling Inverter and Expired Medicine. *(fully implemented)*
+- Toggle for Double or Nothing mode enabling Inverter and Expired Medicine (on by default). *(fully implemented)*
 - Modding API (original uses Godot mods).
 - Scoring: Story uses time and leftover HP as money. Double or Nothing doubles the bank every three rounds; leaderboard via REST API.
 

--- a/BuckshotRoulettePlan.md
+++ b/BuckshotRoulettePlan.md
@@ -32,8 +32,9 @@ The round ends when a player’s HP reaches 0 or the magazine is empty. Winning 
 |------|--------|
 | **Adrenaline** | Steal an item from another player and use it immediately. |
 | **Burner Phone** | Reveals type and position of a random future shell. |
-| **Inverter** | Converts current shell: blank ↔ live. |
-| **Expired Medicine** | 50% chance +2 HP, 50% chance −1 HP. |
+| **Inverter** | Converts current shell: blank ↔ live. *(fully implemented)* |
+| **Expired Medicine** | 50% chance +2 HP, 50% chance −1 HP. *(fully implemented)* |
+These items appear only in Double or Nothing mode.
 
 ### 3.3 Multiplayer only
 | Item | Effect |
@@ -49,7 +50,7 @@ else: |lives − blanks| = 1, lives + blanks = size
 ```
 Magazine is always shuffled on reload.
 
-## 5. Dealer AI *(partially implemented)*
+## 5. Dealer AI *(partially implemented – basic rules working)*
 The single-player Dealer follows deterministic rules:
 - Uses **Magnifying Glass** when the shell is unknown.
 - Uses **Inverter** if facing a blank and wants to attack.
@@ -106,6 +107,7 @@ stateDiagram
 - Adjustable animation speed (0.5×–2×). *(fully implemented)*
 - Option to save RNG seed for replays and debugging. *(fully implemented)*
 - Settings modal to toggle colorblind mode and enter RNG seed. *(fully implemented)*
+- Toggle for Double or Nothing mode enabling Inverter and Expired Medicine. *(fully implemented)*
 - Modding API (original uses Godot mods).
 - Scoring: Story uses time and leftover HP as money. Double or Nothing doubles the bank every three rounds; leaderboard via REST API.
 

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -28,7 +28,8 @@ class Game {
             "Hand Saw"
         ];
         this.extraItems = ["Inverter", "Expired Medicine"];
-        this.doubleMode = false;
+        // enable advanced items by default
+        this.doubleMode = true;
         this.itemPool = this.basicItems.slice();
         this.knownShell = null; // dealer knowledge of next shell
         this.dealerSkip = false; // whether dealer loses next turn

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -20,9 +20,19 @@ class Game {
         this.dealer = new Player('Dealer');
         this.magazine = [];
         this.current = 0;
-        this.itemPool = ['Cigarette Pack', 'Handcuffs', 'Magnifying Glass', 'Beer', 'Hand Saw'];
+        this.basicItems = [
+            "Cigarette Pack",
+            "Handcuffs",
+            "Magnifying Glass",
+            "Beer",
+            "Hand Saw"
+        ];
+        this.extraItems = ["Inverter", "Expired Medicine"];
+        this.doubleMode = false;
+        this.itemPool = this.basicItems.slice();
         this.knownShell = null; // dealer knowledge of next shell
         this.dealerSkip = false; // whether dealer loses next turn
+        this.playerSkip = false; // whether player loses next turn
         this.seed = Date.now();
         this.animationSpeed = 1;
         this.keepMagnify = false; // debug: keep magnifying glass after use
@@ -40,6 +50,11 @@ class Game {
         return this.seed / 233280;
     }
 
+    updateItemPool() {
+        this.itemPool = this.basicItems.slice();
+        if(this.doubleMode) this.itemPool = this.itemPool.concat(this.extraItems);
+    }
+
     startRound() {
         const seedInput = document.getElementById('seedInput');
         if(seedInput && seedInput.value) this.setSeed(Number(seedInput.value));
@@ -48,6 +63,7 @@ class Game {
         this.dealer.hp = this.dealer.maxHp = hp;
         this.player.damageBoost = 1;
         this.dealer.damageBoost = 1;
+        this.updateItemPool();
         this.player.items = this.randomItems();
         this.dealer.items = this.randomItems();
         const magazineSize = 2 + Math.floor(this.random()*7); // 2-8
@@ -55,6 +71,7 @@ class Game {
         this.current = 0;
         this.knownShell = null;
         this.dealerSkip = false;
+        this.playerSkip = false;
         this.updateUI();
         setStatus('Round started. Your move.');
         enableControls();
@@ -105,6 +122,11 @@ class Game {
         if(this.player.hp<=0 || this.dealer.hp<=0) {
             disableControls();
             setStatus((this.player.hp>0?'You win!':'Dealer wins!')+' Start again?');
+            return;
+        }
+        if(this.current>=this.magazine.length){
+            disableControls();
+            setStatus('Magazine empty. Start a new round.');
         }
     }
 
@@ -114,6 +136,14 @@ class Game {
             this.dealerSkip = false;
             return;
         }
+        // restrain player if possible
+        const cuffsIndex = this.dealer.items.indexOf('Handcuffs');
+        if(cuffsIndex > -1) {
+            this.playerSkip = true;
+            this.dealer.items.splice(cuffsIndex,1);
+            this.updateUI();
+            setStatus('Dealer uses Handcuffs on you.');
+        }
         // heal if low hp
         const cigIndex = this.dealer.items.indexOf('Cigarette Pack');
         if(this.dealer.hp <= 2 && cigIndex > -1) {
@@ -121,6 +151,18 @@ class Game {
             this.dealer.items.splice(cigIndex,1);
             this.updateUI();
             setStatus('Dealer uses a Cigarette Pack.');
+        }
+        const medIndex = this.dealer.items.indexOf('Expired Medicine');
+        if(medIndex > -1 && this.dealer.hp < this.dealer.maxHp) {
+            this.dealer.items.splice(medIndex,1);
+            if(this.random() < 0.5) {
+                this.dealer.hp += 2;
+                setStatus('Dealer heals with Expired Medicine.');
+            } else {
+                this.dealer.hp -= 1;
+                setStatus('Dealer is hurt by Expired Medicine.');
+            }
+            this.updateUI();
         }
         // look ahead if unknown
         if(this.knownShell === null) {
@@ -137,6 +179,14 @@ class Game {
             return;
         }
         let nextType = this.knownShell || this.magazine[this.current].type;
+        const invIndex = this.dealer.items.indexOf('Inverter');
+        if(nextType === 'blank' && invIndex > -1) {
+            this.magazine[this.current].type = 'live';
+            nextType = 'live';
+            this.dealer.items.splice(invIndex,1);
+            this.updateUI();
+            setStatus('Dealer inverts the next shell.');
+        }
         if(nextType === 'blank') {
             const beerIndex = this.dealer.items.indexOf('Beer');
             if(beerIndex > -1) {
@@ -177,6 +227,7 @@ const keepCigToggle=document.getElementById('keepCigToggle');
 const speedRange=document.getElementById('speedRange');
 const speedDisplay=document.getElementById('speedDisplay');
 
+const doubleModeToggle=document.getElementById("doubleModeToggle");
 if(colorblindToggle){
     colorblindToggle.addEventListener('change',()=>{
         document.querySelector('.bs-container').classList.toggle('colorblind', colorblindToggle.checked);
@@ -201,6 +252,12 @@ if(speedRange){
     });
     if(speedDisplay) speedDisplay.textContent=speedRange.value+'x';
 }
+if(doubleModeToggle){
+    game.doubleMode = doubleModeToggle.checked;
+    doubleModeToggle.addEventListener("change",()=>{
+        game.doubleMode = doubleModeToggle.checked;
+    });
+}
 
 startBtn.addEventListener('click',()=>game.startRound());
 if(settingsBtn){
@@ -209,10 +266,22 @@ if(settingsBtn){
     });
 }
 shootSelf.addEventListener('click',()=>{
+    if(game.playerSkip){
+        setStatus('You are restrained and lose a turn.');
+        game.playerSkip=false;
+        setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
+        return;
+    }
     game.shoot(game.player, game.player);
     if(game.player.hp>0 && game.dealer.hp>0) setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
 });
 shootDealer.addEventListener('click',()=>{
+    if(game.playerSkip){
+        setStatus('You are restrained and lose a turn.');
+        game.playerSkip=false;
+        setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
+        return;
+    }
     game.shoot(game.dealer, game.player);
     if(game.player.hp>0 && game.dealer.hp>0) setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
 });
@@ -267,6 +336,31 @@ function updateItems(el,items,interactive=false) {
                     game.player.items.splice(i,1);
                     game.updateUI();
                     setStatus('Your next shot will deal double damage.');
+                });
+            }
+            if(it==='Inverter') {
+                div.addEventListener('click',()=>{
+                    if(game.current<game.magazine.length){
+                        const s=game.magazine[game.current];
+                        s.type = s.type==='live'?'blank':'live';
+                        game.player.items.splice(i,1);
+                        game.updateUI();
+                        setStatus('You inverted the next shell.');
+                    }
+                });
+            }
+            if(it==='Expired Medicine') {
+                div.addEventListener('click',()=>{
+                    if(game.player.items[i]!=='Expired Medicine') return;
+                    if(game.random()<0.5){
+                        game.player.hp += 2;
+                        setStatus('Expired Medicine healed you.');
+                    }else{
+                        game.player.hp -= 1;
+                        setStatus('Expired Medicine hurt you.');
+                    }
+                    game.player.items.splice(i,1);
+                    game.updateUI();
                 });
             }
         }

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -54,6 +54,8 @@
             <br>
             <label><input type="checkbox" id="keepCigToggle"> Keep Cigarette Pack</label>
             <br>
+            <label><input type="checkbox" id="doubleModeToggle"> Double or Nothing Mode</label>
+            <br>
             <label>Animation Speed: <span id="speedDisplay">1x</span></label>
             <input id="speedRange" type="range" min="0.5" max="2" step="0.1" value="1">
         </div>

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -54,7 +54,7 @@
             <br>
             <label><input type="checkbox" id="keepCigToggle"> Keep Cigarette Pack</label>
             <br>
-            <label><input type="checkbox" id="doubleModeToggle"> Double or Nothing Mode</label>
+            <label><input type="checkbox" id="doubleModeToggle" checked> Double or Nothing Mode</label>
             <br>
             <label>Animation Speed: <span id="speedDisplay">1x</span></label>
             <input id="speedRange" type="range" min="0.5" max="2" step="0.1" value="1">


### PR DESCRIPTION
## Summary
- add checkbox for Double or Nothing mode in settings
- generate advanced items only when Double or Nothing mode is enabled
- document Double or Nothing toggle and clarify item availability

## Testing
- `node --check js/buckshot.js`

------
https://chatgpt.com/codex/tasks/task_e_6848d74efe608323b7ed0e7323919a32