### PR TITLE
Improve shell visuals and burner phone

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -68,6 +68,10 @@
     background: lightgray;
 }
 
+.shell.current {
+    outline: 1px solid rgba(255,255,255,0.3);
+}
+
 .bs-container.colorblind .shell.live {
     background: repeating-linear-gradient(
         45deg,


### PR DESCRIPTION
## Summary
- highlight the current shell with a subtle outline
- remember shells revealed via Burner Phone
- color known shells only for the player who used Burner Phone

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6848de221dc08323896e2a3dc762744d