### PR TITLE
Implement basic round scoring

### DIFF
--- a/BuckshotRoulettePlan.md
+++ b/BuckshotRoulettePlan.md
@@ -5,7 +5,7 @@
 ## 1. Game Overview *(partially implemented)*
 Buckshot Roulette is a horror-themed variant of Russian roulette played with a shotgun. The goal is to survive three consecutive rounds while reducing opponents to zero charges (HP). The browser version should support both single-player (against an AI Dealer) and multiplayer (up to four players).
 
-## 2. Round Structure *(partially implemented)*
+## 2. Round Structure *(partially implemented – rounds and bank now tracked)*
 Each round goes through several phases:
 
 | Phase | Description | Browser Considerations |
@@ -110,7 +110,7 @@ stateDiagram
 - Settings modal to toggle colorblind mode and enter RNG seed. *(fully implemented)*
 - Toggle for Double or Nothing mode enabling Inverter and Expired Medicine (on by default). *(fully implemented)*
 - Modding API (original uses Godot mods).
-- Scoring: Story uses time and leftover HP as money. Double or Nothing doubles the bank every three rounds; leaderboard via REST API.
+- Scoring: Story uses time and leftover HP as money. Double or Nothing doubles the bank every three rounds; leaderboard via REST API. *(partially implemented – bank and round counter)*
 
 This plan captures the rules, phases, items, AI logic, and architecture necessary to prototype an HTML5 version of **Buckshot Roulette**.
 

--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -18,6 +18,13 @@
     width: 150px;
     text-align: center;
 }
+.info {
+    margin: 10px 0;
+    font-size: 18px;
+}
+.info span {
+    margin: 0 10px;
+}
 .hp-bar {
     width: 100px;
     height: 10px;

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -19,6 +19,10 @@
     </div>
     <div class="bs-container">
         <h1>Buckshot Roulette</h1>
+        <div class="info">
+            Round: <span id="roundNum">0</span>
+            Bank: <span id="bankAmount">0</span>
+        </div>
         <div class="status" id="status">Press Start to begin.</div>
         <div class="controls">
             <button class="baton" id="settingsButton">&#9881;</button><!-- Features button -->


### PR DESCRIPTION
## Summary
- add scoreboard showing current round and bank
- track rounds and bank in game logic
- end rounds and update bank per round
- note bank tracking progress in BuckshotRoulettePlan

## Testing
- `node --check js/buckshot.js`

------
https://chatgpt.com/codex/tasks/task_e_6848dfc1b7448323b871da7e234b5923