### PR TITLE
Add Adrenaline item selection menu

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -109,3 +109,12 @@
     left: 20px;
     z-index: 1100;
 }
+
+#adrenalineTimer {
+    font-size: 20px;
+    margin-bottom: 10px;
+}
+
+#adrenalineItems .item {
+    cursor: pointer;
+}

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -264,6 +264,9 @@ const keepMagToggle=document.getElementById('keepMagToggle');
 const keepCigToggle=document.getElementById('keepCigToggle');
 const speedRange=document.getElementById('speedRange');
 const speedDisplay=document.getElementById('speedDisplay');
+const adrenalineModal=document.getElementById('adrenalineModal');
+const adrenalineItems=document.getElementById('adrenalineItems');
+const adrenalineTimer=document.getElementById('adrenalineTimer');
 
 const doubleModeToggle=document.getElementById("doubleModeToggle");
 if(colorblindToggle){
@@ -391,6 +394,7 @@ function updateItems(el,items,interactive=false) {
                 div.addEventListener('click',()=>{
                     if(game.player.items[i]!=='Adrenaline') return;
                     game.player.items.splice(i,1);
+                    game.updateUI();
                     applyItemEffect(game.player,'Adrenaline');
                 });
             }
@@ -521,14 +525,51 @@ function applyItemEffect(user,item){
             break;
         case 'Adrenaline':
             if(opponent.items.length>0){
-                const idx = Math.floor(game.random()*opponent.items.length);
-                const stolen = opponent.items.splice(idx,1)[0];
-                setStatus((isPlayer?'You':'Dealer')+' steal'+(isPlayer?'':'s')+' '+stolen+' using Adrenaline.');
-                applyItemEffect(user, stolen);
+                if(isPlayer){
+                    showAdrenalineMenu(user, opponent);
+                }else{
+                    const idx = Math.floor(game.random()*opponent.items.length);
+                    const stolen = opponent.items.splice(idx,1)[0];
+                    setStatus('Dealer steals '+stolen+' using Adrenaline.');
+                    applyItemEffect(user, stolen);
+                }
             }else{
                 setStatus(isPlayer?'Dealer has no items to steal.':'You have no items left to steal.');
             }
             break;
     }
     game.updateUI();
+}
+
+let adrenalineInterval;
+function showAdrenalineMenu(user, opponent){
+    adrenalineItems.innerHTML='';
+    adrenalineModal.style.display='flex';
+    let remaining=10;
+    adrenalineTimer.textContent=remaining;
+    adrenalineInterval=setInterval(()=>{
+        remaining--;
+        adrenalineTimer.textContent=remaining;
+        if(remaining<=0){
+            clearInterval(adrenalineInterval);
+            adrenalineModal.style.display='none';
+            const idx=Math.floor(game.random()*opponent.items.length);
+            const stolen=opponent.items.splice(idx,1)[0];
+            setStatus('Time up! You automatically steal '+stolen+'.');
+            applyItemEffect(user, stolen);
+        }
+    },1000);
+    opponent.items.forEach((it,i)=>{
+        const div=document.createElement('div');
+        div.className='item';
+        div.textContent=it;
+        div.addEventListener('click',()=>{
+            clearInterval(adrenalineInterval);
+            adrenalineModal.style.display='none';
+            const stolen=opponent.items.splice(i,1)[0];
+            setStatus('You steal '+stolen+' using Adrenaline.');
+            applyItemEffect(user, stolen);
+        });
+        adrenalineItems.appendChild(div);
+    });
 }

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -64,5 +64,11 @@
             <input id="speedRange" type="range" min="0.5" max="2" step="0.1" value="1">
         </div>
     </div>
+    <div id="adrenalineModal" class="modal">
+        <div class="modal-content">
+            <h2>Choose an item to steal (<span id="adrenalineTimer">10</span>)</h2>
+            <div id="adrenalineItems" class="items"></div>
+        </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- let players pick which item to steal when using Adrenaline in Buckshot Roulette
- style and display a timer for the new Adrenaline modal

## Testing
- `node -c js/buckshot.js`

------
https://chatgpt.com/codex/tasks/task_e_6848e1b9b8148323908d771a604a019b