### PR TITLE
Improve shell highlight and magnifying glass

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -76,7 +76,7 @@
 }
 
 .shell.current {
-    outline: 1px solid rgba(255,255,255,0.3);
+    outline: 2px solid #0f0;
 }
 
 .bs-container.colorblind .shell.live {

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -347,7 +347,9 @@ function updateItems(el,items,interactive=false) {
                 div.addEventListener('click',()=>{
                     if(game.player.items[i]!=='Magnifying Glass') return;
                     if(game.current<game.magazine.length) {
-                        setStatus('Next shell is '+game.magazine[game.current].type);
+                        const type = game.magazine[game.current].type;
+                        setStatus('Next shell is '+type);
+                        game.playerKnown[game.current] = type;
                         if(!game.keepMagnify) game.player.items.splice(i,1);
                         game.updateUI();
                     }
@@ -484,7 +486,9 @@ function applyItemEffect(user,item){
             break;
         case 'Magnifying Glass':
             if(game.current < game.magazine.length){
-                setStatus((isPlayer?'Next shell is ':'Dealer sees next shell is ')+game.magazine[game.current].type);
+                const type = game.magazine[game.current].type;
+                setStatus((isPlayer?'Next shell is ':'Dealer sees next shell is ')+type);
+                if(isPlayer) game.playerKnown[game.current] = type; else game.dealerKnown[game.current] = type;
             }
             break;
         case 'Beer':


### PR DESCRIPTION
## Summary
- tweak shell highlight to be green and thicker
- reveal current shell color when Magnifying Glass is used by a player only for that player

## Testing
- `node --check js/buckshot.js`

------
https://chatgpt.com/codex/tasks/task_e_6848e5f349e4832388efc409d0981898