### PR TITLE
Fix health bar overflow

### DIFF
--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -465,10 +465,12 @@ Game.prototype.updateUI=function(){
     const pBar=document.getElementById('playerHpBar');
     const dBar=document.getElementById('dealerHpBar');
     if(pBar){
-        pBar.style.width=(100*this.player.hp/this.player.maxHp)+'%';
+        const pct = 100 * this.player.hp / this.player.maxHp;
+        pBar.style.width = Math.max(0, Math.min(100, pct)) + '%';
     }
     if(dBar){
-        dBar.style.width=(100*this.dealer.hp/this.dealer.maxHp)+'%';
+        const pct = 100 * this.dealer.hp / this.dealer.maxHp;
+        dBar.style.width = Math.max(0, Math.min(100, pct)) + '%';
     }
     updateItems(document.getElementById('playerItems'),this.player.items,true);
     updateItems(document.getElementById('dealerItems'),this.dealer.items,false);


### PR DESCRIPTION
## Summary
- clamp hp bar width so overheal doesn't overflow UI

## Testing
- `node --check js/buckshot.js`


------
https://chatgpt.com/codex/tasks/task_e_6848e8cee28c8323ab500404a76415c1