### PR TITLE
Add shell counter indicator with toggle

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -118,3 +118,16 @@
 #adrenalineItems .item {
     cursor: pointer;
 }
+
+/* Indicator showing remaining shell counts */
+.shell-indicator {
+    position: fixed;
+    bottom: calc(20px + constant(safe-area-inset-bottom));
+    bottom: calc(20px + env(safe-area-inset-bottom));
+    right: 20px;
+    background: rgba(0, 0, 0, 0.7);
+    padding: 4px 8px;
+    border-radius: 4px;
+    font-size: 14px;
+    z-index: 1100;
+}

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -38,6 +38,7 @@ class Game {
         this.playerSkip = false; // whether player loses next turn
         this.seed = Date.now();
         this.animationSpeed = 1;
+        this.showIndicator = true; // display shell counter
         this.keepMagnify = false; // debug: keep magnifying glass after use
         this.keepCigarette = false; // debug: keep cigarette pack after use
         this.playerKnown = {}; // indices of shells revealed to the player
@@ -290,6 +291,7 @@ const speedDisplay=document.getElementById('speedDisplay');
 const adrenalineModal=document.getElementById('adrenalineModal');
 const adrenalineItems=document.getElementById('adrenalineItems');
 const adrenalineTimer=document.getElementById('adrenalineTimer');
+const indicatorToggle=document.getElementById('indicatorToggle');
 
 const doubleModeToggle=document.getElementById("doubleModeToggle");
 if(colorblindToggle){
@@ -320,6 +322,13 @@ if(doubleModeToggle){
     game.doubleMode = doubleModeToggle.checked;
     doubleModeToggle.addEventListener("change",()=>{
         game.doubleMode = doubleModeToggle.checked;
+    });
+}
+if(indicatorToggle){
+    game.showIndicator = indicatorToggle.checked;
+    indicatorToggle.addEventListener('change',()=>{
+        game.showIndicator = indicatorToggle.checked;
+        game.updateUI();
     });
 }
 
@@ -501,6 +510,14 @@ Game.prototype.updateUI=function(){
     const bankEl = document.getElementById('bankAmount');
     if(roundEl) roundEl.textContent = this.round;
     if(bankEl) bankEl.textContent = this.bank;
+    const indicator = document.getElementById('shellIndicator');
+    if(indicator){
+        const remaining=this.magazine.slice(this.current);
+        const lives=remaining.filter(s=>s.type==='live').length;
+        const blanks=remaining.filter(s=>s.type==='blank').length;
+        indicator.textContent=`Live: ${lives} Blank: ${blanks}`;
+        indicator.style.display=this.showIndicator?'block':'none';
+    }
 };
 
 function applyItemEffect(user,item){

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -45,6 +45,7 @@
             </div>
         </div>
         <div class="magazine" id="magazine"></div>
+        <div id="shellIndicator" class="shell-indicator"></div>
     </div>
     <div id="settingsModal" class="modal">
         <div class="modal-content">
@@ -59,6 +60,8 @@
             <label><input type="checkbox" id="keepCigToggle"> Keep Cigarette Pack</label>
             <br>
             <label><input type="checkbox" id="doubleModeToggle" checked> Double or Nothing Mode</label>
+            <br>
+            <label><input type="checkbox" id="indicatorToggle" checked> Show Shell Counter</label>
             <br>
             <label>Animation Speed: <span id="speedDisplay">1x</span></label>
             <input id="speedRange" type="range" min="0.5" max="2" step="0.1" value="1">


### PR DESCRIPTION
## Summary
- add small shell counter element on the Buckshot Roulette page
- make it configurable from the Features menu

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848f907fa08832384ab7f47bfe54663