### PR TITLE
Add HP monitor to Buckshot Roulette

### DIFF
--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -43,6 +43,7 @@ class Game {
         this.keepCigarette = false; // debug: keep cigarette pack after use
         this.playerKnown = {}; // indices of shells revealed to the player
         this.dealerKnown = {}; // indices of shells revealed to the dealer
+        this.roundOver = false; // track if the current round has ended
     }
 
     setSeed(seed) {
@@ -63,6 +64,7 @@ class Game {
 
     startRound() {
         this.round++;
+        this.roundOver = false;
         const seedInput = document.getElementById('seedInput');
         if(seedInput && seedInput.value) this.setSeed(Number(seedInput.value));
         const hp = 2 + Math.floor(this.random() * 3); // 2-4
@@ -133,7 +135,17 @@ class Game {
         setStatus('New magazine loaded.');
     }
 
+    checkHp(){
+        if(this.roundOver) return;
+        if(this.player.hp<=0 || this.dealer.hp<=0){
+            const winner = this.player.hp>0 ? this.player : this.dealer;
+            this.endRound(winner);
+        }
+    }
+
     endRound(winner) {
+        if(this.roundOver) return;
+        this.roundOver = true;
         disableControls();
         if(winner === this.player) {
             this.bank += this.player.hp;
@@ -510,6 +522,7 @@ Game.prototype.updateUI=function(){
         indicator.textContent=`Live: ${lives} Blank: ${blanks}`;
         indicator.style.display=this.showIndicator?'block':'none';
     }
+    this.checkHp();
 };
 
 function applyItemEffect(user,item){
@@ -620,3 +633,6 @@ function showAdrenalineMenu(user, opponent){
         adrenalineItems.appendChild(div);
     });
 }
+
+// Continuous HP check every 100ms
+setInterval(()=>game.checkHp(),100);


### PR DESCRIPTION
## Summary
- monitor health continuously in Buckshot Roulette
- stop the round when a player reaches zero HP

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684902a61ae88323b0f4a18e8a194e26