### PR TITLE
Add dealer delay slider and handcuff indicator

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -131,3 +131,7 @@
     font-size: 14px;
     z-index: 1100;
 }
+
+.cuff-icon {
+    margin-left: 5px;
+}

--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -38,6 +38,7 @@ class Game {
         this.playerSkip = false; // whether player loses next turn
         this.seed = Date.now();
         this.animationSpeed = 1;
+        this.dealerDelay = 0.5; // delay before dealer acts in seconds
         this.showIndicator = true; // display shell counter
         this.keepMagnify = false; // debug: keep magnifying glass after use
         this.keepCigarette = false; // debug: keep cigarette pack after use
@@ -288,6 +289,8 @@ const keepMagToggle=document.getElementById('keepMagToggle');
 const keepCigToggle=document.getElementById('keepCigToggle');
 const speedRange=document.getElementById('speedRange');
 const speedDisplay=document.getElementById('speedDisplay');
+const delayRange=document.getElementById('delayRange');
+const delayDisplay=document.getElementById('delayDisplay');
 const adrenalineModal=document.getElementById('adrenalineModal');
 const adrenalineItems=document.getElementById('adrenalineItems');
 const adrenalineTimer=document.getElementById('adrenalineTimer');
@@ -318,6 +321,14 @@ if(speedRange){
     });
     if(speedDisplay) speedDisplay.textContent=speedRange.value+'x';
 }
+if(delayRange){
+    delayRange.addEventListener('input',()=>{
+        game.dealerDelay=parseFloat(delayRange.value);
+        if(delayDisplay) delayDisplay.textContent=delayRange.value+'s';
+    });
+    if(delayDisplay) delayDisplay.textContent=delayRange.value+'s';
+    game.dealerDelay=parseFloat(delayRange.value);
+}
 if(doubleModeToggle){
     game.doubleMode = doubleModeToggle.checked;
     doubleModeToggle.addEventListener("change",()=>{
@@ -342,25 +353,25 @@ shootSelf.addEventListener('click',()=>{
     if(game.playerSkip){
         setStatus('You are restrained and lose a turn.');
         game.playerSkip=false;
-        setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
+        setTimeout(()=>game.dealerTurn(),game.dealerDelay*1000);
         return;
     }
     const result = game.shoot(game.player, game.player);
     if(result !== 'blank' &&
        game.player.hp>0 && game.dealer.hp>0 &&
        game.current < game.magazine.length) {
-        setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
+        setTimeout(()=>game.dealerTurn(),game.dealerDelay*1000);
     }
 });
 shootDealer.addEventListener('click',()=>{
     if(game.playerSkip){
         setStatus('You are restrained and lose a turn.');
         game.playerSkip=false;
-        setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
+        setTimeout(()=>game.dealerTurn(),game.dealerDelay*1000);
         return;
     }
     game.shoot(game.dealer, game.player);
-    if(game.player.hp>0 && game.dealer.hp>0) setTimeout(()=>game.dealerTurn(),500/game.animationSpeed);
+    if(game.player.hp>0 && game.dealer.hp>0) setTimeout(()=>game.dealerTurn(),game.dealerDelay*1000);
 });
 
 function updateItems(el,items,interactive=false) {
@@ -510,6 +521,10 @@ Game.prototype.updateUI=function(){
         indicator.textContent=`Live: ${lives} Blank: ${blanks}`;
         indicator.style.display=this.showIndicator?'block':'none';
     }
+    const pcuffs=document.getElementById('playerCuffs');
+    const dcuffs=document.getElementById('dealerCuffs');
+    if(pcuffs) pcuffs.style.display=this.playerSkip?'inline':'none';
+    if(dcuffs) dcuffs.style.display=this.dealerSkip?'inline':'none';
 };
 
 function applyItemEffect(user,item){

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -32,13 +32,13 @@
         </div>
         <div class="players">
             <div class="player" id="player">
-                <h2>Player</h2>
+                <h2>Player <span id="playerCuffs" class="cuff-icon" style="display:none;">⛓</span></h2>
                 <div>HP: <span id="playerHp">3</span></div>
                 <div class="hp-bar"><div class="hp-fill" id="playerHpBar"></div></div>
                 <div id="playerItems" class="items"></div>
             </div>
             <div class="player" id="dealer">
-                <h2>Dealer</h2>
+                <h2>Dealer <span id="dealerCuffs" class="cuff-icon" style="display:none;">⛓</span></h2>
                 <div>HP: <span id="dealerHp">3</span></div>
                 <div class="hp-bar"><div class="hp-fill" id="dealerHpBar"></div></div>
                 <div id="dealerItems" class="items"></div>
@@ -65,6 +65,9 @@
             <br>
             <label>Animation Speed: <span id="speedDisplay">1x</span></label>
             <input id="speedRange" type="range" min="0.5" max="2" step="0.1" value="1">
+            <br>
+            <label>Dealer Delay: <span id="delayDisplay">0.5s</span></label>
+            <input id="delayRange" type="range" min="0" max="2" step="0.1" value="0.5">
         </div>
     </div>
     <div id="adrenalineModal" class="modal">


### PR DESCRIPTION
## Summary
- add display for handcuff effect near Player and Dealer names
- allow adjusting Dealer delay using a new slider in Features modal
- implement dealer delay logic and update UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849695795bc83238a18d307607d511a