### PR TITLE
Add dealer delay to all item actions

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -131,3 +131,7 @@
     font-size: 14px;
     z-index: 1100;
 }
+
+.cuff-icon {
+    margin-left: 5px;
+}

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -32,13 +32,13 @@
         </div>
         <div class="players">
             <div class="player" id="player">
-                <h2>Player</h2>
+                <h2>Player <span id="playerCuffs" class="cuff-icon" style="display:none;">⛓</span></h2>
                 <div>HP: <span id="playerHp">3</span></div>
                 <div class="hp-bar"><div class="hp-fill" id="playerHpBar"></div></div>
                 <div id="playerItems" class="items"></div>
             </div>
             <div class="player" id="dealer">
-                <h2>Dealer</h2>
+                <h2>Dealer <span id="dealerCuffs" class="cuff-icon" style="display:none;">⛓</span></h2>
                 <div>HP: <span id="dealerHp">3</span></div>
                 <div class="hp-bar"><div class="hp-fill" id="dealerHpBar"></div></div>
                 <div id="dealerItems" class="items"></div>
@@ -65,6 +65,9 @@
             <br>
             <label>Animation Speed: <span id="speedDisplay">1x</span></label>
             <input id="speedRange" type="range" min="0.5" max="2" step="0.1" value="1">
+            <br>
+            <label>Dealer Delay: <span id="delayDisplay">0.5s</span></label>
+            <input id="delayRange" type="range" min="0" max="2" step="0.1" value="0.5">
         </div>
     </div>
     <div id="adrenalineModal" class="modal">


### PR DESCRIPTION
## Summary
- allow asynchronous dealer actions by adding `sleep` helper
- apply delay between each item usage in `dealerTurn`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849695795bc83238a18d307607d511a