### PR TITLE
Fix negative HP display

### DIFF
--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -171,6 +171,7 @@ class Game {
         this.freezeIndicator = false;
         if(shell.type==='live') {
             target.hp -= shooter.damageBoost;
+            if(target.hp < 0) target.hp = 0;
             setStatus(shooter.name+' shot '+target.name+'!');
         } else {
             setStatus(shooter.name+' fired a blank.');
@@ -227,6 +228,7 @@ class Game {
                 setStatus('Dealer heals with Expired Medicine.');
             } else {
                 this.dealer.hp -= 1;
+                if(this.dealer.hp < 0) this.dealer.hp = 0;
                 setStatus('Dealer is hurt by Expired Medicine.');
             }
             this.updateUI();
@@ -616,6 +618,7 @@ function applyItemEffect(user,item){
                 setStatus((isPlayer?'Expired Medicine healed you.':'Dealer heals with Expired Medicine.'));
             }else{
                 user.hp -= 1;
+                if(user.hp < 0) user.hp = 0;
                 setStatus((isPlayer?'Expired Medicine hurt you.':'Dealer is hurt by Expired Medicine.'));
             }
             break;


### PR DESCRIPTION
## Summary
- prevent HP from dropping below zero when damage exceeds remaining health

## Testing
- `node --check js/buckshot.js`

------
https://chatgpt.com/codex/tasks/task_e_6849722b4cdc8323b7c1d14aab5a1b1c