### PR TITLE
Update dealer delay slider

### DIFF
--- a/js/buckshot.js
+++ b/js/buckshot.js
@@ -38,7 +38,7 @@ class Game {
         this.playerSkip = false; // whether player loses next turn
         this.seed = Date.now();
         this.animationSpeed = 1;
-        this.dealerDelay = 0.5; // delay before dealer acts in seconds
+        this.dealerDelay = 2; // delay before dealer acts in seconds
         this.showIndicator = true; // display shell counter
         this.keepMagnify = false; // debug: keep magnifying glass after use
         this.keepCigarette = false; // debug: keep cigarette pack after use

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -66,8 +66,8 @@
             <label>Animation Speed: <span id="speedDisplay">1x</span></label>
             <input id="speedRange" type="range" min="0.5" max="2" step="0.1" value="1">
             <br>
-            <label>Dealer Delay: <span id="delayDisplay">0.5s</span></label>
-            <input id="delayRange" type="range" min="0" max="2" step="0.1" value="0.5">
+            <label>Dealer Delay: <span id="delayDisplay">2s</span></label>
+            <input id="delayRange" type="range" min="0" max="4" step="0.1" value="2">
         </div>
     </div>
     <div id="adrenalineModal" class="modal">


### PR DESCRIPTION
## Summary
- extend dealer delay range for Buckshot Roulette
- set default delay to 2 seconds

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68497532e37c8323aab125cad0b66872