### PR TITLE
Improve Buckshot 3D: shotgun model, dealer face, and UI-driven scene interactions

### DIFF
--- a/css/buckshot.css
+++ b/css/buckshot.css
@@ -3,7 +3,83 @@
     flex-direction: column;
     align-items: center;
     margin-top: 20px;
+    gap: 12px;
 }
+
+.bs-scene {
+    position: relative;
+    width: min(1000px, 92vw);
+    height: 520px;
+    border: 2px solid #2c1f1f;
+    border-radius: 14px;
+    overflow: hidden;
+    background: radial-gradient(circle at 20% 20%, #3b2a2a, #120c0c 65%);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+}
+
+#buckshotScene {
+    width: 100%;
+    height: 100%;
+    display: block;
+    image-rendering: pixelated;
+}
+
+.scene-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 18px;
+    color: #f7f0e6;
+    text-shadow: 0 2px 6px rgba(0, 0, 0, 0.8);
+    font-family: 'Orbitron', sans-serif;
+    letter-spacing: 0.08em;
+}
+
+.scene-title {
+    font-size: 18px;
+    opacity: 0.9;
+}
+
+.scene-status {
+    align-self: flex-end;
+    font-size: 14px;
+    background: rgba(0, 0, 0, 0.45);
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.bs-scene::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: linear-gradient(
+            rgba(255, 255, 255, 0.04) 1px,
+            transparent 1px
+        ),
+        linear-gradient(
+            90deg,
+            rgba(255, 255, 255, 0.03) 1px,
+            transparent 1px
+        );
+    background-size: 3px 3px;
+    mix-blend-mode: soft-light;
+    opacity: 0.4;
+    pointer-events: none;
+}
+
+.bs-scene::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at center, rgba(0, 0, 0, 0) 35%, rgba(0, 0, 0, 0.55) 70%, rgba(0, 0, 0, 0.85) 100%);
+    pointer-events: none;
+    mix-blend-mode: multiply;
+}
+
 .controls {
     margin: 10px;
 }

--- a/pages/buckshot.html
+++ b/pages/buckshot.html
@@ -7,6 +7,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="../css/style.css">
     <link rel="stylesheet" href="../css/buckshot.css">
+    <script src="https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.min.js" defer></script>
     <script src="../js/buckshot.js" defer></script>
 </head>
 <body>
@@ -19,6 +20,13 @@
     </div>
     <div class="bs-container">
         <h1>Buckshot Roulette</h1>
+        <div class="bs-scene">
+            <canvas id="buckshotScene"></canvas>
+            <div class="scene-overlay">
+                <div class="scene-title">Dealer Room</div>
+                <div class="scene-status" id="sceneStatus">Awaiting next round...</div>
+            </div>
+        </div>
         <div class="info">
             Round: <span id="roundNum">0</span>
             Bank: <span id="bankAmount">0</span>


### PR DESCRIPTION
### Motivation
- Make the in-scene shotgun and dealer visuals match the reference more closely and remove the misplaced graffiti plane. 
- Surface UI actions into the 3D scene so game events are visible as muzzle flash, recoil, and magazine/shell updates. 
- Add a lightweight dealer face texture to give the dealer a readable visage without heavyweight assets. 
- Provide a simple overlay that mirrors status text from the UI into the scene for synchronized feedback. 

### Description
- Rebuilt the shotgun model and materials inside `initBuckshotScene()` and removed the previous graffiti plane, replacing it with a dealer head using `createDealerFaceTexture()` and subtle hand/shoulder geometry. 
- Added muzzle flash, recoil state, and shell visibility logic with a `sceneState` object and animation updates, and wired `triggerShot()` into `Game.prototype.shoot()` so shots produce visual feedback. 
- Mirrored UI status into the scene via `setStatus()` writing to `#sceneStatus`, and invoked `updateSceneWithGame()` from `Game.prototype.updateUI()` to update shell visibility. 
- Added scene UI/CSS (`.bs-scene` and overlay) and included Three.js in `pages/buckshot.html`, plus helper textures `createGrimeTexture()` and `createTiledTexture()` for tables/walls. 

### Testing
- Started a local static server with `python -m http.server 8000` and it served the site successfully. 
- Ran a Playwright script to open `http://127.0.0.1:8000/pages/buckshot.html` and captured a screenshot (`artifacts/buckshot-3d-v3.png`) to validate rendering and interactions, which succeeded. 
- No unit tests were added since changes are visual/front-end only. 
- The scene initialization (`initBuckshotScene()`), `shoot()` trigger hookup, and `updateSceneWithGame()` were exercised by the visual test above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ebeafa82483238642aef426517068)